### PR TITLE
chore: upgrade zod v3 → v4

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -26,7 +26,7 @@
     "i18next": "npm:i18next@^24.2.1",
     "resvg/": "./shared/resvg/",
     "@resvg/resvg-wasm": "npm:@resvg/resvg-wasm@^2.6.2",
-    "zod": "npm:zod@^3.21.4",
+    "zod": "npm:zod@^4.3.6",
     "xml": "https://deno.land/x/xml@2.1.1/mod.ts",
     "@preact/signals": "npm:@preact/signals@^2.5.0",
     "clsx": "npm:clsx@^2.1.1",

--- a/deno.lock
+++ b/deno.lock
@@ -55,7 +55,7 @@
     "npm:preact@^10.27.2": "10.28.4",
     "npm:satori@~0.18.3": "0.18.4",
     "npm:tailwindcss@^4.2.1": "4.2.1",
-    "npm:zod@^3.21.4": "3.25.76"
+    "npm:zod@^4.3.6": "4.3.6"
   },
   "jsr": {
     "@deno/esbuild-plugin@1.2.1": {
@@ -1104,8 +1104,8 @@
     "yoga-layout@3.2.1": {
       "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="
     },
-    "zod@3.25.76": {
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
+    "zod@4.3.6": {
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="
     }
   },
   "redirects": {
@@ -1495,7 +1495,7 @@
       "npm:preact@^10.27.2",
       "npm:satori@~0.18.3",
       "npm:tailwindcss@^4.2.1",
-      "npm:zod@^3.21.4"
+      "npm:zod@^4.3.6"
     ]
   }
 }


### PR DESCRIPTION
## Summary

- `zod` を `^3.21.4` → `^4.3.6` にアップグレード

## 変更の詳細

既存の使用箇所（`z.object`, `z.enum`, `z.string`, `z.number`, `z.preprocess`, `.superRefine`, `z.infer`）はすべて v4 と互換性があるため、コード変更は不要でした。

## Test plan

- [x] `deno task test` — 33テスト全パス
- [x] `deno lint` — エラーなし
- [x] `deno task build` — ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)