### PR TITLE
chore: remove --allow-sys=homedir permission

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ ADD . /app
 RUN deno cache main.ts
 RUN deno task build
 
-CMD ["serve", "--allow-net", "--allow-env", "--allow-read", "--allow-write", "--allow-sys=homedir", "_fresh/server.js"]
+CMD ["serve", "--allow-net", "--allow-env", "--allow-read", "--allow-write", "_fresh/server.js"]

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -4,7 +4,7 @@
     "start": "deno run -A --watch=static/,routes/ dev.ts",
     "build": "deno run -A dev.ts build",
     "preview": "deno serve -A _fresh/server.js",
-    "test": "deno test --allow-read --allow-write --allow-env --allow-net --allow-sys=homedir"
+    "test": "deno test --allow-read --allow-write --allow-env --allow-net"
   },
   "compilerOptions": { "jsx": "react-jsx", "jsxImportSource": "preact" },
   "imports": {


### PR DESCRIPTION
## Summary

- `deno.jsonc` の `test` タスクから `--allow-sys=homedir` を削除
- `Dockerfile` の `CMD` から `--allow-sys=homedir` を削除

## 背景

この権限は `octokit` メタパッケージが内部で `os.homedir()` を呼んでいたために必要でした。`@octokit/rest` への移行（#1179）により不要になったため削除します。

## Test plan

- [x] `deno task test` — `--allow-sys=homedir` なしで33テスト全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)