### PR TITLE
feat: add baseline security response headers

### DIFF
--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -1,5 +1,6 @@
 import type { Context } from "fresh";
 import { detectLang, init } from "@shared/i18n/mod.ts";
+import { applySecurityHeaders } from "@shared/middleware/security_headers.ts";
 
 export async function handler(ctx: Context<unknown>) {
   const req = ctx.req;
@@ -13,5 +14,5 @@ export async function handler(ctx: Context<unknown>) {
   await init({ lang });
 
   const resp = await ctx.next();
-  return resp;
+  return applySecurityHeaders(resp);
 }

--- a/shared/middleware/security_headers.ts
+++ b/shared/middleware/security_headers.ts
@@ -1,0 +1,31 @@
+// Baseline security response headers applied to every response.
+//
+// Scope is intentionally limited to low-risk, non-breaking headers. The CSP is
+// restricted to `frame-ancestors` (clickjacking protection) and deliberately
+// does NOT set `script-src` / `style-src`, because the site loads Google
+// Analytics and AdSense — enforcing those directives requires a report-only
+// rollout first to avoid breaking ads/analytics.
+const SECURITY_HEADERS: Record<string, string> = {
+  "X-Content-Type-Options": "nosniff",
+  "Referrer-Policy": "strict-origin-when-cross-origin",
+  "X-Frame-Options": "SAMEORIGIN",
+  "Content-Security-Policy": "frame-ancestors 'self'",
+  "Permissions-Policy": "camera=(), geolocation=(), microphone=()",
+  "Strict-Transport-Security": "max-age=31536000",
+};
+
+// This middleware runs globally over responses it does not own. Some of those
+// have immutable headers — a `fetch()` passthrough (the `/posts/images` proxy)
+// or `Response.redirect()` — where `headers.set()` throws. So copy the headers
+// into a fresh `Headers` and rebuild the response instead of mutating in place.
+export function applySecurityHeaders(resp: Response): Response {
+  const headers = new Headers(resp.headers);
+  for (const [name, value] of Object.entries(SECURITY_HEADERS)) {
+    headers.set(name, value);
+  }
+  return new Response(resp.body, {
+    status: resp.status,
+    statusText: resp.statusText,
+    headers,
+  });
+}

--- a/shared/middleware/security_headers_test.ts
+++ b/shared/middleware/security_headers_test.ts
@@ -1,0 +1,98 @@
+import { describe, it } from "std/testing/bdd.ts";
+import { assertEquals } from "std/assert/mod.ts";
+import { applySecurityHeaders } from "./security_headers.ts";
+
+describe("applySecurityHeaders", () => {
+  it("sets X-Content-Type-Options to nosniff", () => {
+    const resp = applySecurityHeaders(new Response("ok"));
+    assertEquals(resp.headers.get("x-content-type-options"), "nosniff");
+  });
+
+  it("sets Referrer-Policy to strict-origin-when-cross-origin", () => {
+    const resp = applySecurityHeaders(new Response("ok"));
+    assertEquals(
+      resp.headers.get("referrer-policy"),
+      "strict-origin-when-cross-origin",
+    );
+  });
+
+  it("sets X-Frame-Options to SAMEORIGIN", () => {
+    const resp = applySecurityHeaders(new Response("ok"));
+    assertEquals(resp.headers.get("x-frame-options"), "SAMEORIGIN");
+  });
+
+  it("sets a frame-ancestors CSP without restricting scripts or styles", () => {
+    const resp = applySecurityHeaders(new Response("ok"));
+    assertEquals(
+      resp.headers.get("content-security-policy"),
+      "frame-ancestors 'self'",
+    );
+  });
+
+  it("disables unused features via Permissions-Policy", () => {
+    const resp = applySecurityHeaders(new Response("ok"));
+    assertEquals(
+      resp.headers.get("permissions-policy"),
+      "camera=(), geolocation=(), microphone=()",
+    );
+  });
+
+  it("sets HSTS for this host only (no includeSubDomains)", () => {
+    const resp = applySecurityHeaders(new Response("ok"));
+    assertEquals(
+      resp.headers.get("strict-transport-security"),
+      "max-age=31536000",
+    );
+  });
+
+  it("preserves the response status, statusText, and body", async () => {
+    const resp = applySecurityHeaders(
+      new Response("hello body", { status: 201, statusText: "Created" }),
+    );
+    assertEquals(resp.status, 201);
+    assertEquals(resp.statusText, "Created");
+    assertEquals(await resp.text(), "hello body");
+  });
+
+  it("preserves headers that were already set", () => {
+    const resp = applySecurityHeaders(
+      new Response("ok", {
+        headers: {
+          "content-type": "image/png",
+          "cache-control": "public, max-age=60",
+        },
+      }),
+    );
+    assertEquals(resp.headers.get("content-type"), "image/png");
+    assertEquals(resp.headers.get("cache-control"), "public, max-age=60");
+    assertEquals(resp.headers.get("x-content-type-options"), "nosniff");
+  });
+
+  it("overwrites a conflicting security header already on the response", () => {
+    const resp = applySecurityHeaders(
+      new Response("ok", {
+        headers: {
+          "x-frame-options": "DENY",
+          "content-security-policy": "default-src 'none'",
+        },
+      }),
+    );
+    // `.set()` (not `.append()`) must win, leaving a single clean value.
+    assertEquals(resp.headers.get("x-frame-options"), "SAMEORIGIN");
+    assertEquals(
+      resp.headers.get("content-security-policy"),
+      "frame-ancestors 'self'",
+    );
+  });
+
+  it("does not throw on a response with immutable headers", () => {
+    // `fetch()` passthroughs (the image proxy) and redirects have immutable
+    // headers; the middleware must reconstruct rather than throw, while
+    // preserving status and pre-existing headers like Location.
+    const immutable = Response.redirect("https://example.com/", 302);
+    const resp = applySecurityHeaders(immutable);
+    assertEquals(resp.status, 302);
+    assertEquals(resp.headers.get("location"), "https://example.com/");
+    assertEquals(resp.headers.get("x-content-type-options"), "nosniff");
+  });
+});


### PR DESCRIPTION
## Summary

- 全レスポンスに低リスクのセキュリティヘッダーを付与するミドルウェア `applySecurityHeaders` を追加
- `routes/_middleware.ts` で `ctx.next()` の結果に適用

## 背景

しばらく更新していなかったため脆弱性チェックを実施したところ、セキュリティレスポンスヘッダーが未設定だったため対応。`modern-web-guidance` の security ガイドに沿い、まずは破壊リスクの無い companion ヘッダー＋クリックジャッキング対策から導入する。

## 付与するヘッダー

| ヘッダー | 値 |
|---|---|
| X-Content-Type-Options | `nosniff` |
| Referrer-Policy | `strict-origin-when-cross-origin` |
| X-Frame-Options | `SAMEORIGIN` |
| Content-Security-Policy | `frame-ancestors 'self'` |
| Permissions-Policy | `camera=(), geolocation=(), microphone=()` |
| Strict-Transport-Security | `max-age=31536000` |

## 設計上の判断

- **CSPは `frame-ancestors` のみ**。`script-src`/`style-src` は今回付けない。GA/AdSense があるため strict CSP は report-only での段階導入が必要で、別途対応予定
- **HSTSは `includeSubDomains`/`preload` なし**。このホストのみHTTPS強制し、他subdomainに影響させない
- `applySecurityHeaders` は **Response を再構築**して返す。グローバルミドルウェアは headers が immutable なレスポンス（`/posts/images` の `fetch` 透過・リダイレクト）も通るため、`headers.set()` の in-place 変更だと `TypeError` で 500 になる（Deno実機で確認）

## Test plan

- [x] `deno task test` — 34 passed / 65 steps（新規10ケース: 全ヘッダー値・status/body保持・既存ヘッダー保持・上書き・immutableレスポンス回帰）
- [x] `deno lint` / `deno fmt --check`
- [x] 型チェック（全 `.ts`/`.tsx`）
- [x] `deno task build` — 成功

## 補足

`ts-implementation-workflow` で実装。code-reviewer が immutable レスポンスの Critical を検出し修正済み。security-reviewer はセッション上限で未完了のため、要件6ヘッダーの存在・値はユニットテストで担保している。本格CSP（script-src/style-src）の report-only 導入は次の取り組み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)