### PR TITLE
fix: prevent path globbing in purge-cache workflow

### DIFF
--- a/.github/workflows/purge-cache.yml
+++ b/.github/workflows/purge-cache.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       paths:
-        description: Enter the path to be purged."
+        description: Path(s) to invalidate, space-separated. Use /* for everything.
         required: true
         type: string
 
@@ -15,7 +15,15 @@ jobs:
       contents: read
     steps:
       - name: Purge Cache
-        run: aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION_ID --paths $TARGET_PATHS
+        # `set -f` disables filename globbing so a value like `/*` is sent to
+        # CloudFront literally instead of expanding to the runner's root dirs
+        # (/bin /etc ...). $TARGET_PATHS stays unquoted so multiple
+        # space-separated paths are still passed as separate arguments.
+        run: |
+          set -f
+          aws cloudfront create-invalidation \
+            --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" \
+            --paths $TARGET_PATHS
         env:
           TARGET_PATHS: ${{ inputs.paths }}
           CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}


### PR DESCRIPTION
## Summary

- `purge-cache.yml` の `--paths $TARGET_PATHS` が未クォートで、`/*` 指定時に**ランナーのファイルシステムのルート配下に glob 展開**されていた問題を修正

## 原因

ワークフローを `/*` でディスパッチすると、bash の pathname 展開で `$TARGET_PATHS` が `/Applications /bin /cores /dev /etc ...`（実機検証）に展開され、`aws cloudfront create-invalidation` がサイトではなく**これらの無意味なパスを無効化**していた。aws CLI は exit 0 を返すため**"success" 表示でも実際のキャッシュは消えていない**。

## 修正内容

- `set -f` で glob を無効化 → `/*` を CloudFront にリテラルで送出
- `$TARGET_PATHS` は**非クォートのまま**維持 → 複数パスをスペース区切りで渡したときに別引数として展開される挙動を保持
- `$CLOUDFRONT_DISTRIBUTION_ID` をクォート
- input の `description` のタイポ修正＋用法明記（`/*` で全パージ）

```diff
-        run: aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION_ID --paths $TARGET_PATHS
+        run: |
+          set -f
+          aws cloudfront create-invalidation \
+            --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" \
+            --paths $TARGET_PATHS
```

## Test plan

- [x] YAML パース確認（`@std/yaml`）、`run` ブロックの内容を検証
- [x] `set -f` 下で `/*` が glob されずリテラル送出されること、複数パスが分割維持されることをローカル bash で確認
- [ ] マージ後、`/*` でディスパッチして CloudFront invalidation が正しいパスで作成されることを確認

## 補足

先日の脆弱性チェックで挙げた項目（`purge-cache.yml` の未クォート）の対応。セキュリティヘッダー反映のための全キャッシュパージにこの修正が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)