### PR TITLE
fix: add viewport and charset meta tags for mobile responsiveness

### DIFF
--- a/routes/_app.tsx
+++ b/routes/_app.tsx
@@ -10,6 +10,8 @@ export default function App({ Component }: PageProps) {
   return (
     <html lang="ja">
       <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link
           rel="preconnect"


### PR DESCRIPTION
## Summary

- `routes/_app.tsx` の `<head>` に **viewport メタ**と **charset メタ**を追加し、モバイルで非レスポンシブだった問題を修正

## 背景・原因

Fresh 2 移行で `_app.tsx` の `<head>` を自前定義した際に **viewport メタが欠落**していた。viewport が無いとモバイルブラウザは ~980px のデスクトップ幅で描画してから縮小表示するため、Tailwind のレスポンシブ指定（`sm:` 等）が一切発火せず「デスクトップ版の縮小」になっていた。charset メタも欠落していたため併せて head 先頭に追加。

## 変更

```tsx
<meta charset="utf-8" />
<meta name="viewport" content="width=device-width, initial-scale=1" />
```

アクセシビリティのため `user-scalable=no` / `maximum-scale` は付けない（ピンチズーム維持）。

## Test plan

- [x] `deno task build` 成功 / `deno task test` 35 passed・回帰なし
- [x] `deno lint` / `deno fmt --check` / 型チェック
- [x] **実サーバ（`deno task preview`）で配信HTMLに両メタ出力・HTTP 200 を確認**
- [ ] デプロイ後、モバイル実機/devtools で表示確認

## レビュー

- **ts-accessibility-reviewer: Approve** — zoom保持の viewport で WCAG 1.4.4 (Resize Text) / 1.4.10 (Reflow) を満たす、charset配置・`lang="ja"` 妥当、新たなバリアなしで純粋に改善

🤖 Generated with [Claude Code](https://claude.com/claude-code)