### PR TITLE
refactor: make image proxy origin stateless and SSRF-safe

### DIFF
--- a/domains/post/shared/replace_image.ts
+++ b/domains/post/shared/replace_image.ts
@@ -1,17 +1,28 @@
 const REPLACED_URL_PREFIX = "/posts/images";
 
-let originalOrigin = "";
+// MicroCMS serves uploaded images from this fixed assets CDN. Pinning it as a
+// constant (instead of carrying the origin in module state or in the proxied
+// URL) keeps the rewrite stateless and means the image proxy can only ever
+// fetch from this trusted host — the request can influence the path, never the
+// origin, so there is no SSRF surface.
+const ASSETS_ORIGIN = "https://images.microcms-assets.io";
 
 export function replaceToReplacedUrl(originalUrl: URL): string {
-  originalOrigin = originalUrl.origin;
+  // Only proxy MicroCMS assets; any other image is returned untouched so the
+  // browser loads it directly and the proxy is never pointed elsewhere.
+  if (originalUrl.origin !== ASSETS_ORIGIN) {
+    return originalUrl.toString();
+  }
   return REPLACED_URL_PREFIX + originalUrl.pathname + originalUrl.search;
 }
 
 export function replaceToOriginalUrl(replacedUrl: URL): string {
-  replacedUrl.pathname = replacedUrl.pathname.replace(REPLACED_URL_PREFIX, "");
-  replacedUrl.searchParams.delete("__frsh_c");
-  const originalUrl = new URL(originalOrigin);
-  originalUrl.pathname = replacedUrl.pathname;
+  const pathname = replacedUrl.pathname.startsWith(REPLACED_URL_PREFIX)
+    ? replacedUrl.pathname.slice(REPLACED_URL_PREFIX.length)
+    : replacedUrl.pathname;
+  const originalUrl = new URL(ASSETS_ORIGIN);
+  originalUrl.pathname = pathname;
   originalUrl.search = replacedUrl.search;
+  originalUrl.searchParams.delete("__frsh_c");
   return originalUrl.toString();
 }

--- a/domains/post/shared/replace_image_test.ts
+++ b/domains/post/shared/replace_image_test.ts
@@ -2,15 +2,51 @@ import { describe, it } from "std/testing/bdd.ts";
 import { assertEquals } from "std/assert/mod.ts";
 import { replaceToOriginalUrl, replaceToReplacedUrl } from "./replace_image.ts";
 
-describe("replaceToOriginalUrl/replaceToReplacedUrl", () => {
-  it("can be replaced, and the replacement is restored", () => {
-    const originalUrl = new URL("https://example.com/test?w=500");
-    const replacedUrlString = replaceToReplacedUrl(originalUrl);
-    assertEquals(replacedUrlString, "/posts/images/test?w=500");
+const ASSETS = "https://images.microcms-assets.io";
+const SITE = "https://mya-ake.com";
 
-    const originalUrlString = replaceToOriginalUrl(
-      new URL(replacedUrlString, "https://example.net"),
+describe("replaceToReplacedUrl", () => {
+  it("rewrites a MicroCMS assets URL to the same-origin proxy path", () => {
+    const url = new URL(`${ASSETS}/assets/svc/file/neko.png?w=500`);
+    assertEquals(
+      replaceToReplacedUrl(url),
+      "/posts/images/assets/svc/file/neko.png?w=500",
     );
-    assertEquals(originalUrlString, "https://example.com/test?w=500");
+  });
+
+  it("leaves a non-MicroCMS image URL untouched (not proxied)", () => {
+    const url = new URL("https://example.com/img.png?w=1");
+    assertEquals(replaceToReplacedUrl(url), "https://example.com/img.png?w=1");
+  });
+});
+
+describe("replaceToOriginalUrl", () => {
+  it("reconstructs the MicroCMS URL from the proxy request with no prior render call (stateless)", () => {
+    // Deliberately does NOT call replaceToReplacedUrl first: proves the module
+    // keeps no shared state, so a cold instance / concurrent request is correct.
+    const req = new URL("/posts/images/assets/svc/file/neko.png?w=500", SITE);
+    assertEquals(
+      replaceToOriginalUrl(req),
+      `${ASSETS}/assets/svc/file/neko.png?w=500`,
+    );
+  });
+
+  it("drops the Fresh __frsh_c cache-busting query param", () => {
+    const req = new URL(
+      "/posts/images/assets/x/y/z.png?w=500&__frsh_c=abc",
+      SITE,
+    );
+    assertEquals(replaceToOriginalUrl(req), `${ASSETS}/assets/x/y/z.png?w=500`);
+  });
+});
+
+describe("round trip", () => {
+  it("restores the original MicroCMS URL", () => {
+    const original = new URL(`${ASSETS}/assets/x/y/z.png?w=500`);
+    const replaced = replaceToReplacedUrl(original);
+    assertEquals(
+      replaceToOriginalUrl(new URL(replaced, SITE)),
+      original.toString(),
+    );
   });
 });


### PR DESCRIPTION
## Summary

- 画像プロキシ `replace_image.ts` のモジュールレベル可変グローバル `originalOrigin` を撤去し、信頼オリジンを定数化
- ステートレス化により**コールドスタートバグ**と**並行リクエストの誤オリジン参照**を解消。同時に SSRF 面も塞ぐ

## 背景・問題

`originalOrigin` はレンダリング時の副作用でセットされ画像リクエスト時に読まれるモジュールグローバルだった。これにより:

- **コールドスタートバグ**: 該当 post を未レンダリングの新規 Cloud Run インスタンスに画像リクエストが来ると `originalOrigin === ""` → `new URL("")` が throw → 400
- **並行性**: グローバルが「直近にどの post をレンダリングしたか」を反映し、リクエスト間でオリジンが混線し得た

## 変更

- 信頼オリジンを定数化: `const ASSETS_ORIGIN = "https://images.microcms-assets.io"`（実 MicroCMS API で実画像ホストを確認）
- `replaceToReplacedUrl`: オリジンが assets の時だけ proxy 化、それ以外は元 URL をそのまま返す（直接ロード）
- `replaceToOriginalUrl`: 定数オリジンで再構築（グローバル参照なし）。prefix strip は先頭アンカー化、引数を非破壊に
- リクエストが影響できるのは `/posts/images/` 以下のパスのみで fetch 先ホストは固定 → **SSRF 面なし**

## Test plan

- [x] `deno task test` — 37 passed / 93 steps（新規: assets書換・非assets素通し・**ステートレス性（事前レンダリング無しで再構築）**・`__frsh_c` 除去・round trip）
- [x] `deno lint` / `deno fmt --check` / 型チェック / `deno task build`

## レビュー

- **ts-security-reviewer: 承認** — 厳密にセキュリティ改善。`@host`/`//host`/`../`/`%2e%2e`/CRLF/`https://evil.com` 埋め込み等の SSRF スマグリングを実機テスト → 全て `images.microcms-assets.io` に再構築、オリジン偽装不可
- **ts-code-reviewer**: Critical なし。Minor 指摘（prefix strip の先頭アンカー化・引数の非破壊化）を反映済み

## スコープ外（フォローアップ候補）

code-reviewer 指摘の「`RenderHTML` 側 `new URL(node.attrs.src)` が相対 src で throw」は**既存問題**（MicroCMS は常に絶対 URL のため発火せず）。本 PR の対象外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)