### PR TITLE
chore: harden Dockerfile and add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# VCS / editor / tooling
+.git
+.github
+.githooks
+.vscode
+.claude
+
+# Local env & secrets — must never be copied into the image
+.envrc
+
+# Build artifacts & dependencies: regenerated inside the container, and the
+# host copies are the wrong architecture (macOS) for the linux image.
+_fresh
+node_modules
+.tmp
+
+# Docker / CI / docs not needed inside the image
+Dockerfile
+.dockerignore
+docker-compose.yml
+cloudbuild.yaml
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,19 @@ FROM denoland/deno:2.7.2
 EXPOSE 8000
 
 ARG GIT_REVISION
-ARG MICRO_CMS_API_KEY
-ARG MICRO_CMS_API_ENDPOINT
 ENV DENO_DEPLOYMENT_ID=${GIT_REVISION}
-ENV MICRO_CMS_API_KEY=${MICRO_CMS_API_KEY}
-ENV MICRO_CMS_API_ENDPOINT=${MICRO_CMS_API_ENDPOINT}
+
+# Secrets (MICRO_CMS_API_KEY / MICRO_CMS_API_ENDPOINT) are NOT baked into the
+# image. They are injected at runtime as Cloud Run service env vars, and are not
+# needed for `deno task build`.
 
 WORKDIR /app
 
-ADD . /app
+COPY . /app
 
 RUN deno cache main.ts
 RUN deno task build
 
-CMD ["serve", "--allow-net", "--allow-env", "--allow-read", "--allow-write", "_fresh/server.js"]
+# No --allow-write: the local file cache only runs when APP_ENV != "prod"
+# (getUseMicroCMSCache), so the production server never writes to disk.
+CMD ["serve", "--allow-net", "--allow-env", "--allow-read", "_fresh/server.js"]


### PR DESCRIPTION
## Summary

- `.dockerignore` を新設し、Dockerfile をハードニング（脆弱性チェック項目4）

## 背景

`ADD . /app` ＋ `.dockerignore` 無しのため、`.git` / ローカルの `.envrc`（実 MicroCMS APIキー）/ `node_modules`（macOSアーキ）/ `_fresh` 等がビルドコンテキスト・イメージに混入していた。加えて APIキーを ARG→ENV でイメージに焼き込み、prod では不要な `--allow-write` を付与していた。

## 変更

- **`.dockerignore` 新設**: `.git` / `.envrc`(秘密) / `node_modules`(誤アーキ) / `_fresh` / `.claude` / CI・docs 等を除外
- **APIキーの ARG/ENV 焼き込みを削除**: `deno task build` に不要（検証済）。実行時は Cloud Run の service env で注入される
- **`--allow-write` 削除**: ローカルファイルキャッシュは `APP_ENV != "prod"`（`getUseMicroCMSCache`）の時のみ動作 → prod は無書き込み。本番に `APP_ENV=prod` 設定済みであることは `cache-control` ヘッダーで確認済
- **`ADD` → `COPY`**

## 検証

- [x] Dockerfile のビルド2ステップ（`deno cache main.ts` / `deno task build`）が MicroCMS env 無しで成功することをローカルで確認
- [x] `.dockerignore` が `main.ts`/`dev.ts`/`deno.jsonc`/`deno.lock`/`routes`/`domains`/`shared`/`core`/`islands`/`static` を除外しないことを確認
- [x] `deno fmt --check` / `deno lint` 緑
- [ ] **`docker build` 自体は未検証**（ローカルに Docker デーモン無し）。イメージ構造（root・FROM・手順）は不変なので影響は限定的。次タグ時の Cloud Build で最終確認

## スコープ外（フォローアップ）

- **非root化（`USER deno`）**: `DENO_DIR` と `/app` の所有権調整が必要で Docker ビルド検証が前提のため別 PR に分離（未検証で入れると次デプロイで Cloud Build が失敗し得る）
- 実行時権限のさらなる絞り込み（`--allow-net`/`--allow-read`/`--allow-env` のスコープ化）は保守コスト高のため今回見送り

🤖 Generated with [Claude Code](https://claude.com/claude-code)