### PR TITLE
feat(design): fluid type scale & muted tone in primitives (S02)

### DIFF
--- a/shared/ui/list/OrderList.tsx
+++ b/shared/ui/list/OrderList.tsx
@@ -7,6 +7,9 @@ type Props = {
 };
 
 export function OrderList(props: Props) {
-  const className = clsx("grid list-outside list-decimal pl-4", props.class);
+  const className = clsx(
+    "grid gap-2 list-outside list-decimal pl-4",
+    props.class,
+  );
   return <ol class={className}>{props.children}</ol>;
 }

--- a/shared/ui/list/UnorderList.tsx
+++ b/shared/ui/list/UnorderList.tsx
@@ -11,7 +11,7 @@ type Props = {
 export function UnorderList(props: Props) {
   const { children, listStyleType = "disc", class: cls } = props;
   const className = clsx(
-    "grid list-outside",
+    "grid gap-2 list-outside",
     listStyleType === "disc" ? "pl-4 list-disc" : "p-0 list-none",
     cls,
   );

--- a/shared/ui/text/Heading.tsx
+++ b/shared/ui/text/Heading.tsx
@@ -15,10 +15,14 @@ const fontSizeClassMap: Record<FontSize, string> = {
 };
 
 export type Level = "1" | "2" | "3" | "4" | "5" | "6";
+
+// Default level sizing uses the fluid display scale from S01 (text-h*), which
+// carries its own paired line-height — so no leading class is applied by
+// default, keeping that paired line-height the single source (review note D3).
 const fontSizeMap: Record<Level, string> = {
-  "1": "text-3xl",
-  "2": "text-2xl",
-  "3": "text-xl",
+  "1": "text-h1",
+  "2": "text-h2",
+  "3": "text-h3",
   "4": "text-lg",
   "5": "text-base",
   "6": "text-base",
@@ -41,7 +45,7 @@ export type HeadingProps = {
 export function Heading(props: HeadingProps) {
   const {
     level,
-    leading = "base",
+    leading,
     srOnly = false,
     children,
     fontSize,
@@ -53,7 +57,7 @@ export function Heading(props: HeadingProps) {
   const className = clsx(
     "m-0 font-bold",
     fontSize ? fontSizeClassMap[fontSize] : fontSizeMap[level],
-    leadingMap[leading],
+    leading && leadingMap[leading],
     srOnly && "sr-only",
     extraClass?.toString(),
   );

--- a/shared/ui/text/Text.tsx
+++ b/shared/ui/text/Text.tsx
@@ -43,6 +43,12 @@ const lineStyleMap: Record<LineStyle, string> = {
   "nowrap": "whitespace-nowrap",
 };
 
+type Tone = "default" | "muted";
+const toneMap: Record<Tone, string> = {
+  default: "",
+  muted: "text-muted",
+};
+
 type Props = {
   as?: "p" | "span";
   children: ComponentChildren;
@@ -50,6 +56,7 @@ type Props = {
   fontWeight?: FontWeight;
   leading?: Leading;
   lineStyle?: LineStyle;
+  tone?: Tone;
   class?: string;
 } & JSX.HTMLAttributes<HTMLParagraphElement>;
 
@@ -61,6 +68,7 @@ export function Text(props: Props) {
     fontWeight = "normal",
     leading = "paragraph",
     lineStyle = "new-line",
+    tone = "default",
     style: attrStyle,
     class: extraClass,
     ...restAttrs
@@ -71,6 +79,7 @@ export function Text(props: Props) {
     fontWeightMap[fontWeight],
     leadingMap[leading],
     lineStyleMap[lineStyle],
+    toneMap[tone],
     extraClass?.toString(),
   );
 


### PR DESCRIPTION
## Summary

- デザイン刷新（**design-refresh-2026**）の **S02 / コンテンツ primitives**。S01 のデザイントークンを各 primitive で消費
- 視覚レベルのみ。コンポーネント API は後方互換

## 変更

- **Heading**: レベル 1–3 を流体トークン `text-h1/h2/h3`（S01）にマップ。デフォルトの `leading-*` を廃し、トークンの paired line-height を**単一ソース**に → **S01 レビュー指摘 D3 を解消**
- **Text**: 任意の `tone="muted"`（`--color-muted`）を追加。メタ情報・副次テキスト用
- **OrderList / UnorderList**: `gap-2` で縦リズム
- **リンク**: 変更なし（下線リファインは S01 の base layer に集約済み）

## Test plan

- [x] `deno task build`（Tailwind が `.text-h1/h2/h3` `.text-muted` `clamp()` を生成）
- [x] `deno lint` / `deno fmt --check` / 型チェック
- [x] `deno task test` — 37 passed / 93 steps・回帰なし
- [ ] 目視（モバイル 375px / デスクトップ：見出しスケール・muted・リスト間隔）← レビュー時

## 補足

`design-refresh-2026` スタックの **2/9**（依存: S01 #1189）。S01 レビューの D1（`text-rendering`）/ D2（`color-scheme` meta in `_app.tsx`）は本PRの範囲外で、`static/styles.css` の follow-up（色味調整とまとめる予定）。`gated` cadence のため、本PRマージで次の S03 が着手可能になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)