### PR TITLE
fix(design): drop global optimizeLegibility & add color-scheme meta

### DIFF
--- a/routes/_app.tsx
+++ b/routes/_app.tsx
@@ -12,6 +12,7 @@ export default function App({ Component }: PageProps) {
       <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="color-scheme" content="dark" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link
           rel="preconnect"

--- a/static/styles.css
+++ b/static/styles.css
@@ -40,7 +40,6 @@
     line-height: 1.75; /* relaxed reading rhythm */
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    text-rendering: optimizeLegibility;
   }
 
   p {


### PR DESCRIPTION
## Summary

- S01 デザイントークンのレビュー指摘（#1189 の **D1 / D2**）への follow-up

## 変更

- **D1**: `static/styles.css` の `body { text-rendering: optimizeLegibility }` を削除。長文/モバイルでレイアウト性能コストがある割に効果が薄いため、ブラウザ既定に戻す
- **D2**: `routes/_app.tsx` の head に `<meta name="color-scheme" content="dark">` を追加。CSS 読み込み前にブラウザが暗スキーム（フォームコントロール・スクロールバー・既定キャンバス）を適用し、ライトフラッシュを防ぐ

## Test plan

- [x] `deno task build`（生成CSSから `text-rendering` 消失を確認）
- [x] `deno lint` / `deno fmt --check` / 型チェック
- [x] `deno task test` — 37 passed / 93 steps・回帰なし
- [ ] 目視（初回ロードのライトフラッシュ無し・表示崩れ無し）

## 補足

`design-refresh-2026` の slice ではなく、S01 レビューの follow-up（`static/styles.css` + `routes/_app.tsx`）。スライス進行とは独立にマージ可。今後の色味調整も同種の `static/styles.css` 変更としてここに準じて対応できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)