### PR TITLE
feat(design): editorial tokens, fonts & global CSS (S01)

### DIFF
--- a/routes/_app.tsx
+++ b/routes/_app.tsx
@@ -20,7 +20,7 @@ export default function App({ Component }: PageProps) {
           crossOrigin="anonymous"
         />
         <link
-          href="https://fonts.googleapis.com/css2?family=Red+Hat+Display&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Schibsted+Grotesk:wght@400;500;600;700;800&family=Noto+Sans+JP:wght@400;500;700&family=JetBrains+Mono:wght@400;500&display=swap"
           rel="stylesheet"
         />
         <link rel="stylesheet" href="/styles.css" />

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,5 +1,7 @@
 @import "tailwindcss";
-@import "../core/css/modern-normalize.css";
+/* Layered so the reset no longer outranks `@layer base` — otherwise its
+   unlayered `body { font-family: system-ui }` defeats the editorial body font. */
+@import "../core/css/modern-normalize.css" layer(base);
 
 @theme {
   /* Colors — refined editorial dark */

--- a/static/styles.css
+++ b/static/styles.css
@@ -2,31 +2,43 @@
 @import "../core/css/modern-normalize.css";
 
 @theme {
-  /* Colors — refined neutral dark ramp (quiet dark minimalism).
-     Token names are unchanged so existing utilities keep working; only the
-     values are refined, plus a few new semantic tokens for later slices. */
-  --color-background: #18181b; /* deep neutral charcoal (was blue-ish slate) */
-  --color-surface: #1f1f23; /* raised surface for cards/sections */
-  --color-text: #e8e8ea; /* soft off-white, less glare than pure #fff */
-  --color-muted: #a1a1aa; /* secondary text / metadata */
-  --color-link: #e8e8ea; /* monochrome links; underline refined in base */
-  --color-border: #2a2a30; /* subtle, low-contrast hairline */
-  --color-hr: #3f3f46; /* quiet rule */
-  --color-code: #e8e8ea; /* inline code text */
-  --color-code-bg: #27272a; /* inline code background */
+  /* Colors — refined editorial dark */
+  --color-background: #141416; /* page base */
+  --color-surface: #1c1c1f; /* raised surface */
+  --color-raised: #232327; /* cards / code chrome */
+  --color-elevated: #0f0f11; /* footer colophon — recessed */
+  --color-text: #ededee; /* primary text */
+  --color-muted: #9b9ba3; /* secondary text */
+  --color-faint: #6c6c75; /* meta / mono labels */
+  --color-border: #2b2b31; /* visible hairline */
+  --color-hairline: #1f1f24; /* faint row divider */
+  --color-rule: #26262b; /* section rule */
+  --color-hr: #26262b;
+  --color-link: #ededee; /* monochrome links */
+  --color-accent: #e0b27d; /* warm sand — the single accent */
+  --color-code: #cfcfd4;
+  --color-code-bg: #1f1f24;
 
-  /* Fluid display type scale (clamp: rem + vw) — consumed by headings in S02 */
-  --text-display: clamp(2.25rem, 1.6rem + 2.6vw, 3.25rem);
-  --text-display--line-height: 1.1;
-  --text-h1: clamp(1.75rem, 1.4rem + 1.4vw, 2.25rem);
+  /* Fonts */
+  --font-sans: "Schibsted Grotesk", "Noto Sans JP", system-ui, sans-serif;
+  --font-logo: "Schibsted Grotesk", sans-serif; /* display / masthead */
+  --font-mono: "JetBrains Mono", ui-monospace, monospace; /* meta / code */
+
+  /* Fluid type scale (clamp) — paired with each token's line-height */
+  --text-masthead: clamp(2.75rem, 1.6rem + 5vw, 5.125rem);
+  --text-masthead--line-height: 0.9;
+  --text-display: clamp(2.25rem, 1.6rem + 2.6vw, 3.5rem);
+  --text-display--line-height: 1.05;
+  --text-h1: clamp(1.875rem, 1.4rem + 1.6vw, 2.75rem);
   --text-h1--line-height: 1.2;
-  --text-h2: clamp(1.4rem, 1.2rem + 0.9vw, 1.7rem);
-  --text-h2--line-height: 1.25;
-  --text-h3: clamp(1.2rem, 1.1rem + 0.5vw, 1.35rem);
-  --text-h3--line-height: 1.3;
+  --text-h2: 1.5625rem; /* 25px */
+  --text-h2--line-height: 1.3;
+  --text-h3: 1.1875rem; /* 19px */
+  --text-h3--line-height: 1.35;
 
-  /* Display font */
-  --font-logo: "Red Hat Display", sans-serif;
+  /* Spacing rhythm */
+  --spacing-section: 2.75rem; /* between numbered sections (44px) */
+  --spacing-reading: 41.25rem; /* article reading measure (660px) */
 }
 
 @layer base {
@@ -35,9 +47,10 @@
   }
 
   body {
+    font-family: var(--font-sans);
     color: var(--color-text);
     background-color: var(--color-background);
-    line-height: 1.75; /* relaxed reading rhythm */
+    line-height: 1.75;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
@@ -52,56 +65,82 @@
   h4,
   h5,
   h6 {
-    line-height: 1.2;
+    font-family: var(--font-logo);
+    letter-spacing: -0.02em;
     text-wrap: balance;
   }
 
   a {
+    /* monochrome at rest; warm-sand accent underline on hover */
     text-decoration: underline;
     text-decoration-thickness: 1px;
     text-underline-offset: 0.2em;
-    /* quiet underline at rest, full on hover */
-    text-decoration-color: color-mix(in oklab, currentColor 45%, transparent);
+    text-decoration-color: color-mix(in oklab, currentColor 40%, transparent);
     transition: text-decoration-color 0.15s ease;
   }
   a:hover {
-    text-decoration-color: currentColor;
+    text-decoration-color: var(--color-accent);
   }
 }
 
 @layer components {
-  /* RenderHTML: adjacent selectors */
-  .rh-p + ul,
-  .rh-p + ol {
-    margin-top: 1rem;
-  }
-  .rh-ul + p,
-  .rh-ol + p {
-    margin-top: 1rem;
-  }
-  .rh-p:has(span.cms-space) {
-    margin-top: 1rem;
-  }
-
-  /* Breadcrumbs: ::after pseudo-element */
-  .bc-link-item::after {
-    content: ">";
-    padding-left: 0.5rem;
-  }
-
-  /* Container */
+  /* Container — index pages widen; articles use .reading */
   .app-container {
-    margin-left: auto;
-    margin-right: auto;
-  }
-  @media (min-width: 640px) {
-    .app-container {
-      max-width: 640px;
-    }
+    margin-inline: auto;
   }
   @media (min-width: 768px) {
     .app-container {
-      max-width: 768px;
+      max-width: 920px;
     }
+  }
+
+  /* Article reading measure (660px) */
+  .reading {
+    max-width: var(--spacing-reading);
+    margin-inline: auto;
+  }
+
+  /* Mono eyebrow label — "01 — ABOUT" */
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--color-faint);
+  }
+
+  /* Heavy rule under the masthead */
+  .masthead-rule {
+    height: 2px;
+    background: var(--color-text);
+  }
+
+  /* TOC leader row — dotted leader stretches between label and value */
+  .toc-row {
+    display: flex;
+    align-items: baseline;
+    gap: 0.875rem;
+    padding: 0.625rem 0;
+  }
+  .toc-lead {
+    flex: 1;
+    border-bottom: 1px dotted #3a3a40;
+    transform: translateY(-4px);
+  }
+
+  /* Breadcrumbs separator */
+  .bc-link-item::after {
+    content: "›";
+    padding-left: 0.5rem;
+    color: var(--color-faint);
+  }
+
+  /* RenderHTML: adjacent selectors */
+  .rh-p + ul,
+  .rh-p + ol,
+  .rh-ul + p,
+  .rh-ol + p,
+  .rh-p:has(span.cms-space) {
+    margin-top: 1rem;
   }
 }


### PR DESCRIPTION
## Summary

- デザイン刷新（**design-refresh-2026 v2 / Editorial**）の **S01 / 土台スライス**。Claude Design の handoff に基づく Editorial dark のトークン・フォント・global CSS
- 旧 dark トークン（#1189）を**上書き**。視覚/CSS のみ、ルーティング・データ・情報設計は不変

## 変更

- **`static/styles.css` @theme**: editorial パレット（`#141416` base + surface/raised/elevated/faint/hairline/rule の意味トークン + 唯一のアクセント warm-sand `#e0b27d`）、3フォント（Schibsted Grotesk / Noto Sans JP / JetBrains Mono）、fluid scale（masthead/display/h1/h2/h3）+ spacing（section 44px / reading 660px）
- **@layer base**: sans 本文、見出しは logo フォント + `-0.02em`、リンクは hover で accent 下線
- **@layer components**: `.app-container` 920px、`.reading` 660px、`.eyebrow`（mono ラベル）、`.masthead-rule`、`.toc-row/.toc-lead`、パンくず `›`。既存 `.rh-*` 維持
- **`routes/_app.tsx`**: フォント `<link>` を Red Hat Display → 3ファミリーへ

## 過渡状態（レビュー注意）

S01 は**トークン/フォントのみ**。ページ/シェルは S02–S07 まで旧レイアウトのままなので、サイトは **"半 editorial"** に見えます（配色・フォント・見出しサイズ・accent ホバーは全体適用、マストヘッド/左レール/年別一覧/記事 reading 幅は後続スライス）。既存ページは壊れません。

## Test plan

- [x] `deno task build`（生成CSS に `#141416`・accent `#e0b27d`・Schibsted/JetBrains・`.app-container` 920px・`.eyebrow`・`.reading` を確認）
- [x] `deno lint` / `deno fmt --check` / 型チェック
- [x] `deno task test` — 37 passed / 93 steps・回帰なし
- [ ] 目視（モバイル 375px / デスクトップ：フォント読込・editorial 配色・920px 幅・accent ホバー）← レビュー時

## 補足

`design-refresh-2026` を Editorial デザインへ **in-place 再計画**した v2 の **1/8**。旧 v1 スタック（dark refined）は `_v1/` に退避、旧 S01 #1189 は本PRが上書き。`gated` cadence のため本PRマージで S02 着手可能になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)