### PR TITLE
feat(design): editorial meta text & arrow list markers (S02)

### DIFF
--- a/shared/ui/list/UnorderList.tsx
+++ b/shared/ui/list/UnorderList.tsx
@@ -1,7 +1,16 @@
 import { ComponentChildren } from "preact";
 import { clsx } from "clsx";
 
-type ListStyleType = "disc" | "none";
+type ListStyleType = "arrow" | "disc" | "none";
+
+const markerMap: Record<ListStyleType, string> = {
+  // editorial "▸" markers in the accent colour; each item becomes a flex row
+  arrow:
+    "p-0 list-none [&>li]:flex [&>li]:gap-2 [&>li]:before:content-['▸'] [&>li]:before:text-accent [&>li]:before:shrink-0",
+  disc: "pl-4 list-disc",
+  none: "p-0 list-none",
+};
+
 type Props = {
   children: ComponentChildren;
   listStyleType?: ListStyleType;
@@ -9,10 +18,10 @@ type Props = {
 };
 
 export function UnorderList(props: Props) {
-  const { children, listStyleType = "disc", class: cls } = props;
+  const { children, listStyleType = "arrow", class: cls } = props;
   const className = clsx(
     "grid gap-2 list-outside",
-    listStyleType === "disc" ? "pl-4 list-disc" : "p-0 list-none",
+    markerMap[listStyleType],
     cls,
   );
   return <ul class={className}>{children}</ul>;

--- a/shared/ui/text/Text.tsx
+++ b/shared/ui/text/Text.tsx
@@ -43,10 +43,17 @@ const lineStyleMap: Record<LineStyle, string> = {
   "nowrap": "whitespace-nowrap",
 };
 
-type Tone = "default" | "muted";
+type Tone = "default" | "muted" | "faint";
 const toneMap: Record<Tone, string> = {
   default: "",
   muted: "text-muted",
+  faint: "text-faint",
+};
+
+type FontFamily = "sans" | "mono";
+const fontFamilyMap: Record<FontFamily, string> = {
+  sans: "",
+  mono: "font-mono",
 };
 
 type Props = {
@@ -57,6 +64,7 @@ type Props = {
   leading?: Leading;
   lineStyle?: LineStyle;
   tone?: Tone;
+  font?: FontFamily;
   class?: string;
 } & JSX.HTMLAttributes<HTMLParagraphElement>;
 
@@ -69,6 +77,7 @@ export function Text(props: Props) {
     leading = "paragraph",
     lineStyle = "new-line",
     tone = "default",
+    font = "sans",
     style: attrStyle,
     class: extraClass,
     ...restAttrs
@@ -80,6 +89,7 @@ export function Text(props: Props) {
     leadingMap[leading],
     lineStyleMap[lineStyle],
     toneMap[tone],
+    fontFamilyMap[font],
     extraClass?.toString(),
   );
 


### PR DESCRIPTION
## Summary

- デザイン刷新（**design-refresh-2026 v2 / Editorial**）の **S02 / コンテンツ primitives**。S01 の editorial トークンを各 primitive で消費
- 視覚のみ。コンポーネント API は後方互換

## 変更

- **`Text`**: `tone="faint"`（`--color-faint`）と `font="mono"`（JetBrains Mono）を追加 — 日付/メタを editorial の mono-faint ラベルで描画できるように。デフォルトは不変
- **`UnorderList`**: editorial の **▸ accent マーカー**（`list-none` + flex 行）を新デフォルトに。`disc`/`none` も維持
- **`Heading`**: 既に levels 1–3 → `text-h1/h2/h3`（v1 primitive スライス）→ 変更なし。**Links**: `text-link` 維持（accent ホバー下線は base 処理）。CTA（`font-mono text-accent`）はページ側で `class` 適用

## 過渡的注意

`UnorderList` のデフォルトを ▸ にしたため、既存のコンポーネントリスト（Home の Posts/GitHub、記事一覧、**記事本文の RenderHTML リスト（ネスト含む）**）が S04–S06 で再構成されるまで ▸ 表示になります。インクリメンタル配信として想定内。記事本文リストの仕上げ（ネスト/インデント/ol・ul 混在）は **S06（記事詳細 + RenderHTML）** で確定。`Text` の mono/faint はまだ消費箇所なし（S04–S06 で使用）。

## Test plan

- [x] `deno task build`（生成CSS に ▸ マーカー・`.text-faint`・`font-mono`/JetBrains を確認）
- [x] `deno lint` / `deno fmt --check` / 型チェック
- [x] `deno task test` — 37 passed / 93 steps（`MICRO_CMS_*` env 下。CI 同条件）
- [ ] 目視（モバイル/デスクトップ：▸ マーカーの表示・整列）← レビュー時

## 補足

`design-refresh-2026` v2 の **2/8**（依存: S01 #1192）。旧 v1 S02 #1190 はマージ済み。`gated` cadence のため本PRマージで S03（アプリシェル）着手可能に。

🤖 Generated with [Claude Code](https://claude.com/claude-code)