### PR TITLE
feat(design): editorial Home — left-rail & numbered index (S04)

### DIFF
--- a/domains/home/pages/Home.tsx
+++ b/domains/home/pages/Home.tsx
@@ -1,11 +1,9 @@
-import { Fragment } from "preact";
 import { DefaultAppShell } from "@shared/ui/app_shells/DefaultAppShell.tsx";
-import { Section } from "@shared/ui/section/Section.tsx";
-import { Grid } from "@shared/ui/layout/Grid.tsx";
+import { Heading } from "@shared/ui/text/Heading.tsx";
 import { Time } from "@shared/ui/text/Time.tsx";
+import { InternalLink } from "@shared/ui/link/InternalLink.tsx";
 import { StyledExternalLink } from "@shared/ui/link/StyledExternalLink.tsx";
 import { StyledInternalLink } from "@shared/ui/link/StyledInternalLink.tsx";
-import { ListItem, UnorderList } from "@shared/ui/list/mod.ts";
 import { translate } from "@shared/i18n/mod.ts";
 import { SEOHead } from "@shared/head/SEOHead.tsx";
 import { RenderHTML } from "@shared/render/RenderHTML.tsx";
@@ -13,7 +11,31 @@ import { createBreadcrumbs } from "@shared/breadcrumbs/manager.ts";
 import type { PageProps } from "fresh";
 import type { Data } from "./Home.handler.ts";
 
+// Same source as the footer colophon; kept local until a shared profile resource
+// is extracted (follow-up — see DefaultFooter.getSocialItems).
+function getSocialItems(): { label: string; name: string; uri: string }[] {
+  return [
+    {
+      label: translate("social:github"),
+      name: translate("social:gitHubName"),
+      uri: "https://github.com/mya-ake",
+    },
+    {
+      label: translate("social:x"),
+      name: translate("social:xName"),
+      uri: "https://twitter.com/mya_ake",
+    },
+    {
+      label: translate("social:zenn"),
+      name: translate("social:zennName"),
+      uri: "https://zenn.dev/mya_ake",
+    },
+  ];
+}
+
 export function Home({ data }: PageProps<Data>) {
+  const socialItems = getSocialItems();
+
   return (
     <DefaultAppShell
       widgetMap={data.widgetMap}
@@ -23,71 +45,107 @@ export function Home({ data }: PageProps<Data>) {
         description={translate("description:default")}
         path="/"
       />
-      <div class="px-4">
-        <Section
-          level="1"
-          heading={translate("home:heading")}
-          headingProps={{ srOnly: true }}
-          isContainer
-        >
-          <Grid templateColumns="auto" rowGap="48px">
-            <Section level="2" heading="About">
-              <div class="mt-2">
+      <div class="app-container px-4">
+        <Heading level="1" srOnly>{translate("home:heading")}</Heading>
+
+        <div class="grid gap-12 md:grid-cols-[200px_1fr]">
+          {/* Left rail — profile + social */}
+          <aside aria-label={translate("profile:heading")}>
+            <img
+              src="/assets/v3/images/avatar.jpg"
+              width="60"
+              height="60"
+              class="rounded-full"
+              alt=""
+            />
+            <p class="mt-4 font-logo text-xl">
+              {translate("profile:nameWithYomi")}
+            </p>
+            <ul class="mt-6 grid gap-2 list-none p-0 font-mono text-[0.78rem]">
+              {socialItems.map(({ label, name, uri }) => (
+                <li
+                  key={uri}
+                  class="flex justify-between gap-3 border-b border-hairline pb-[7px]"
+                >
+                  <span class="text-muted">{label}</span>
+                  <StyledExternalLink href={uri}>@{name}</StyledExternalLink>
+                </li>
+              ))}
+            </ul>
+          </aside>
+
+          {/* Right column — numbered editorial index */}
+          <div class="grid gap-section">
+            <section>
+              <h2 class="eyebrow mb-3">01 — About</h2>
+              <div class="text-code leading-[1.9]">
                 <RenderHTML html={data.widgetMap.home_about} />
               </div>
-            </Section>
+            </section>
 
-            <Section level="2" heading="Posts">
-              <div class="mt-2">
-                <UnorderList>
-                  {data.posts.contents.map(({ id, title, publishedAt }) => (
-                    <Fragment key={id}>
-                      <ListItem>
+            <section>
+              <h2 class="eyebrow mb-3">02 — Posts</h2>
+              <ol class="m-0 list-none p-0">
+                {data.posts.contents.map(
+                  ({ id, title, publishedAt }, index) => (
+                    <li key={id} class="toc-row">
+                      <span class="font-mono text-muted text-xs">
+                        {String(index + 1).padStart(2, "0")}
+                      </span>
+                      <StyledInternalLink href={`/posts/${id}`}>
+                        {title}
+                      </StyledInternalLink>
+                      <span class="toc-lead" aria-hidden="true" />
+                      <span class="shrink-0 font-mono text-muted text-xs">
                         <Time
                           datetime={publishedAt}
                           displayFormat="YYYY.MM.DD"
-                        />{" "}
-                        <StyledInternalLink href={`/posts/${id}`}>
-                          {title}
-                        </StyledInternalLink>
-                      </ListItem>
-                    </Fragment>
-                  ))}
-                </UnorderList>
-              </div>
-              <div class="mt-4">
-                <StyledInternalLink href="/posts">
-                  一覧へ
-                </StyledInternalLink>
-              </div>
-            </Section>
+                        />
+                      </span>
+                    </li>
+                  ),
+                )}
+              </ol>
+              <InternalLink
+                href="/posts"
+                class="mt-4 inline-block font-mono text-accent text-[0.8125rem] no-underline"
+              >
+                記事一覧へ →
+              </InternalLink>
+            </section>
 
-            <Section level="2" heading="Recent Activities">
-              <div class="mt-2">
+            <section>
+              <h2 class="eyebrow mb-3">03 — Recent Activities</h2>
+              <div class="text-code leading-[1.7]">
                 <RenderHTML html={data.widgetMap.home_recent_activities} />
               </div>
-            </Section>
+            </section>
 
-            <Section level="2" heading="GitHub Activities">
-              <div class="mt-2">
-                <UnorderList>
-                  {data.repositories.map((
-                    { id, name, html_url, description },
-                  ) => (
-                    <Fragment key={id}>
-                      <ListItem>
-                        <StyledExternalLink href={html_url}>
-                          {name}
-                        </StyledExternalLink>
-                        <span>: {description}</span>
-                      </ListItem>
-                    </Fragment>
-                  ))}
-                </UnorderList>
-              </div>
-            </Section>
-          </Grid>
-        </Section>
+            <section>
+              <h2 class="eyebrow mb-3">04 — GitHub</h2>
+              <ul class="m-0 list-none p-0">
+                {data.repositories.map(
+                  ({ id, name, html_url, description }) => (
+                    <li
+                      key={id}
+                      class="grid grid-cols-[140px_1fr] gap-4 border-t border-hairline py-3"
+                    >
+                      <StyledExternalLink
+                        href={html_url}
+                        class="font-mono text-link text-[0.84rem]"
+                      >
+                        {name}
+                      </StyledExternalLink>
+                      <span class="text-muted text-sm leading-snug">
+                        {description}
+                      </span>
+                    </li>
+                  ),
+                )}
+              </ul>
+            </section>
+          </div>
+        </div>
       </div>
     </DefaultAppShell>
   );


### PR DESCRIPTION
## Summary

- デザイン刷新（**design-refresh-2026 v2 / Editorial**）の **S04 / Home ページ**。Home を editorial レイアウトに再構成
- 視覚のみ。**ハンドラ・データ・i18n キーは不変**（`domains/home/pages/Home.tsx` の1ファイルのみ、+117/-59）

## 変更

- **レイアウト**: 単一カラムの `<Section>` 積み上げ → **左レール（200px）＋ 右本文（1fr）** の2カラムグリッド（`md:grid-cols-[200px_1fr]`・gap 48px・md 未満で1カラム）。コンテナは `app-container`（920px・マストヘッドと整列）、`<h1>` は `sr-only`（視覚ブランドはマストヘッド）
- **左レール**（`<aside aria-label="Profile">`）: アバター60px ＋ `nameWithYomi`（`font-logo`）＋ ソーシャル（mono・`border-hairline` 罫・label `text-muted` / `@name` リンク）
- **右本文**（`gap-section` 44px）: `<h2 class="eyebrow">` の番号付き 01–04 セクション
  - **02 Posts**: S01 の `.toc-row`/`.toc-lead` による**ドットリーダー行**（番号・タイトル・リーダー・日付）＋「記事一覧へ →」accent リンク
  - **04 GitHub**: `grid-cols-[140px_1fr]` の**ハードライン罫テーブル**（リポジトリ名 mono ＋ 説明）
  - **01 About / 03 Recent**: 既存ウィジェットを `RenderHTML`（`text-code`）
- **トークン**: マージ済み S01 のみ再利用（`.eyebrow`〔AA muted〕・`.toc-row`/`.toc-lead`・`gap-section`・`text-code`/`-muted`/`-accent`・`border-hairline`）。新規トークンなし

## 既知の判断ポイント（レビュー向け）

- **03 Recent Activities**: CMS を `RenderHTML` で素のまま描画（デザインの accent「—」リスト化は S06 の RenderHTML 範疇・非ブロッキング）
- **名前**: `profile:nameWithYomi`（mya-ake（みゃけ））を1行で（footer と統一）。原本の2行表記とは差異
- **`getSocialItems()` 重複**: footer から複製（未 export）。共有 `shared/profile` 抽出は follow-up

## Test plan

- [x] `deno fmt --check` / `deno lint` / 型チェック
- [x] `deno task build`
- [x] `deno task test` — 38 passed / 96 steps・回帰なし
- [x] ブラウザ実測: container 920px / 外側グリッド `200px/640px` gap 48px / eyebrow 11px mono muted(AA) / posts ドットリーダー＋右寄せ日付 / GitHub `140px/484px`
- [ ] 目視（desktop + mobile 375px）

🤖 Generated with [Claude Code](https://claude.com/claude-code)