### PR TITLE
feat(design): editorial post detail page & RenderHTML restyle (S06)

### DIFF
--- a/domains/post/pages/details/PostDetails.tsx
+++ b/domains/post/pages/details/PostDetails.tsx
@@ -1,10 +1,9 @@
 import { DefaultAppShell } from "@shared/ui/app_shells/DefaultAppShell.tsx";
 import { SEOHead } from "@shared/head/SEOHead.tsx";
 import { HighlightJSHead } from "@shared/head/HighlightJSHead.tsx";
-import { Section } from "@shared/ui/section/Section.tsx";
-import { Grid } from "@shared/ui/layout/Grid.tsx";
-import { Text } from "@shared/ui/text/Text.tsx";
+import { Heading } from "@shared/ui/text/Heading.tsx";
 import { Time } from "@shared/ui/text/Time.tsx";
+import { InternalLink } from "@shared/ui/link/InternalLink.tsx";
 import { RenderHTML } from "@shared/render/RenderHTML.tsx";
 import Highlight from "@islands/Highlight.tsx";
 import { isSameDate } from "@shared/date/is_same_date.ts";
@@ -14,13 +13,15 @@ import type { PageProps } from "fresh";
 import type { Data } from "./PostDetails.handler.ts";
 
 export function PostDetails({ data }: PageProps<Data>) {
+  const { post } = data;
   const breadcrumbs = createBreadcrumbs({
     label: translate("posts:name"),
     to: "/posts",
   }, {
-    label: data.post.title,
-    to: `/posts/${data.post.id}`,
+    label: post.title,
+    to: `/posts/${post.id}`,
   });
+  const isUpdated = !isSameDate(post.publishedAt, post.updatedAt);
 
   return (
     <DefaultAppShell
@@ -28,38 +29,56 @@ export function PostDetails({ data }: PageProps<Data>) {
       breadcrumbs={breadcrumbs}
     >
       <SEOHead
-        title={data.post.title}
-        description={data.post.description}
+        title={post.title}
+        description={post.description}
         path="/posts/"
       />
       <HighlightJSHead />
       <div class="px-4">
-        <Section level="1" heading={data.post.title} isContainer>
-          <Grid
-            templateColumns="auto 1fr"
-            columnGap="8px"
-            class="mt-4"
-          >
-            <Text fontSize="sm">
-              <Time
-                datetime={data.post.publishedAt}
-                displayFormat="YYYY.MM.DD"
-              />
-            </Text>
-            {!isSameDate(data.post.publishedAt, data.post.updatedAt) && (
-              <Text fontSize="sm">
-                ({translate("immutable:updatedDate")}:{" "}
-                <Time
-                  datetime={data.post.updatedAt}
-                  displayFormat="YYYY.MM.DD"
-                />)
-              </Text>
+        <article class="reading">
+          <header>
+            <p class="m-0 font-mono text-accent text-xs tracking-[0.1em]">
+              <Time datetime={post.publishedAt} displayFormat="YYYY.MM.DD" />
+            </p>
+            <Heading
+              level="1"
+              class="mt-3.5 tracking-[-0.03em] leading-[1.2]"
+            >
+              {post.title}
+            </Heading>
+            {post.tags.length > 0 && (
+              <ul class="mt-[18px] flex flex-wrap gap-2 m-0 p-0 list-none">
+                {post.tags.map((tag) => (
+                  <li key={tag.id}>
+                    <span class="font-mono text-muted text-[0.6875rem] border border-border rounded-full px-[11px] py-[3px]">
+                      {tag.title}
+                    </span>
+                  </li>
+                ))}
+              </ul>
             )}
-          </Grid>
-          <div class="mt-8">
-            <RenderHTML html={data.post.body} />
+          </header>
+
+          <div class="my-8 h-px bg-rule" />
+
+          <div class="text-code [&_p]:text-[1.0625rem] [&_p]:leading-[1.95]">
+            <RenderHTML html={post.body} />
           </div>
-        </Section>
+
+          <footer class="mt-10 flex items-center justify-between border-t border-rule pt-6 font-mono text-xs">
+            {isUpdated
+              ? (
+                <span class="text-muted">
+                  {translate("immutable:updatedDate")}{" "}
+                  <Time datetime={post.updatedAt} displayFormat="YYYY.MM.DD" />
+                </span>
+              )
+              : <span />}
+            <InternalLink href="/posts" class="text-accent no-underline">
+              ← 記事一覧へ
+            </InternalLink>
+          </footer>
+        </article>
       </div>
       <Highlight />
     </DefaultAppShell>

--- a/shared/render/RenderHTML.tsx
+++ b/shared/render/RenderHTML.tsx
@@ -33,7 +33,7 @@ function render(nodes: Node[]) {
           <Heading
             id={node.attrs.id}
             level={level}
-            class={marginClass}
+            class={clsx(marginClass, "text-text")}
             style={node.attrs.style}
           >
             {render(node.childNodes)}
@@ -75,12 +75,16 @@ function render(nodes: Node[]) {
         return <s style={node.attrs.style}>{render(node.childNodes)}</s>;
       }
       case "code": {
+        // Block code (inside <pre>, carries a `language-*` class) is left plain
+        // for highlight.js / the code-block chrome; only inline code gets the
+        // editorial accent chip.
+        const isBlockCode = (node.attrs.class ?? "").includes("language");
         return (
           <code
             style={node.attrs.style}
-            class={clsx(
+            class={isBlockCode ? node.attrs.class : clsx(
               node.attrs.class,
-              "text-code px-[7px] bg-code-bg rounded",
+              "text-accent px-[7px] py-px bg-code-bg rounded",
             )}
           >
             {render(node.childNodes)}
@@ -91,7 +95,7 @@ function render(nodes: Node[]) {
         return (
           <blockquote
             style={node.attrs.style}
-            class="my-4 border-l-4 border-text leading-relaxed"
+            class="my-7 border-l-2 border-accent pl-[22px] italic text-muted leading-relaxed"
           >
             {render(node.childNodes)}
           </blockquote>
@@ -99,9 +103,19 @@ function render(nodes: Node[]) {
       }
       case "figure": {
         return (
-          <figure class="my-4" style={node.attrs.style}>
+          <figure class="my-7" style={node.attrs.style}>
             {render(node.childNodes)}
           </figure>
+        );
+      }
+      case "figcaption": {
+        return (
+          <figcaption
+            class="mt-2.5 text-center font-mono text-muted text-xs"
+            style={node.attrs.style}
+          >
+            {render(node.childNodes)}
+          </figcaption>
         );
       }
       case "img": {
@@ -152,7 +166,9 @@ function render(nodes: Node[]) {
       }
       case "pre": {
         return (
-          <pre class="block m-0 my-4 max-w-[calc(100vw-2rem)]">{render(node.childNodes)}</pre>
+          <pre class="block m-0 my-7 max-w-[calc(100vw-2rem)] overflow-x-auto rounded-xl border border-rule bg-surface p-[18px] font-mono text-[0.8125rem] leading-[1.85] text-code">
+            {render(node.childNodes)}
+          </pre>
         );
       }
       case "hr": {

--- a/shared/ui/list/UnorderList.tsx
+++ b/shared/ui/list/UnorderList.tsx
@@ -4,9 +4,11 @@ import { clsx } from "clsx";
 type ListStyleType = "arrow" | "disc" | "none";
 
 const markerMap: Record<ListStyleType, string> = {
-  // editorial "▸" markers in the accent colour; each item becomes a flex row
+  // editorial "▸" markers in the accent colour. The marker is absolutely
+  // positioned in a left gutter (not a flex row) so a nested <ul>/<ol> inside an
+  // <li> flows as a normal block instead of being laid out beside the text.
   arrow:
-    "p-0 list-none [&>li]:flex [&>li]:gap-2 [&>li]:before:content-['▸'] [&>li]:before:text-accent [&>li]:before:shrink-0",
+    "p-0 list-none [&>li]:relative [&>li]:pl-6 [&>li]:before:content-['▸'] [&>li]:before:absolute [&>li]:before:left-0 [&>li]:before:text-accent",
   disc: "pl-4 list-disc",
   none: "p-0 list-none",
 };


### PR DESCRIPTION
## Summary

- 記事詳細ページ（`/posts/:id`）と本文レンダラ（`RenderHTML`）を editorial デザインへ更新
- 視覚のみ。ルーティング・データ取得・i18n は不変。`RenderHTML` の URL サニタイズ／画像プロキシ処理には手を入れていない

## 変更

- **`domains/post/pages/details/PostDetails.tsx`**: 記事を `.reading`（660px・中央寄せ）の本文カラムに再構成
  - ヘッダー: accent のモノスペース公開日 → display 見出し `<h1>` → タグピル（`post.tags`、モノ・`rounded-full`）
  - ヘッダー下に区切り罫、本文は記事スコープで 17px / line-height 1.95 の prose（`text-code`）
  - 記事フッター: 更新日（公開日と異なる場合のみ）＋「← 記事一覧へ」リンク。公開日はヘッダー、更新日はフッターに配置
- **`shared/render/RenderHTML.tsx`**（className / ラッパーのみ）:
  - インラインコード → accent チップ。`<pre>` 内のブロックコード（`language-*`）は highlight.js 用に素のまま（二重装飾の回避）
  - blockquote → accent の左罫＋イタリック＋muted
  - `<pre>` → コードブロックの枠（角丸・境界線・`bg-surface`・横スクロール）
  - `<figcaption>` の描画を追加（これまで未対応で脱落していた）
  - 見出しを `text-text` 固定（本文の `text-code` の中でも見出しの明度を保持）
- **`shared/ui/list/UnorderList.tsx`**: 「▸」マーカーを各 `<li>` の flex 行から左ガターの絶対配置へ変更。ネストした `<ul>`/`<ol>` が項目の**右隣に並ばず下にブロックとして流れる**よう修正（記事本文のネストリスト崩れの解消）

## セキュリティ境界

- `RenderHTML.tsx` の `safeHref()`（href スキームのサニタイズ）と `replaceToReplacedUrl()`（画像プロキシのオリジン固定）は**変更なし**（diff 上 byte-identical）。今回の変更は表示用の className / ラッパー / `<figcaption>` 追加のみ

## Test plan

- [x] `deno fmt --check` / `deno lint` / 型チェック
- [x] `deno task build`
- [x] `deno task test` — 39 passed / 101 steps・回帰なし
- [x] ブラウザ実測（`/posts/different-versions-in-monorepo`）: `article.reading` = 660px 中央寄せ / コードブロック枠（#1c1c1f・角丸12px）/ blockquote muted+italic / 戻りリンク accent / 本文 #cfcfd4・17px、見出し #ededee
- [x] ネストリスト: 親項目に対しネスト `<ul>` が下方向にブロックとして配置されることを実測確認
- [ ] 目視（desktop + mobile 375px）

🤖 Generated with [Claude Code](https://claude.com/claude-code)