### PR TITLE
feat(design): editorial privacy policy page (S07)

### DIFF
--- a/domains/privacy/pages/PrivacyPolicy.tsx
+++ b/domains/privacy/pages/PrivacyPolicy.tsx
@@ -2,7 +2,6 @@ import { DefaultAppShell } from "@shared/ui/app_shells/DefaultAppShell.tsx";
 import { translate } from "@shared/i18n/mod.ts";
 import { SEOHead } from "@shared/head/SEOHead.tsx";
 import { createBreadcrumbs } from "@shared/breadcrumbs/manager.ts";
-import { Section } from "@shared/ui/section/Section.tsx";
 import { RenderHTML } from "@shared/render/RenderHTML.tsx";
 import type { PageProps } from "fresh";
 import type { Data } from "./PrivacyPolicy.handler.ts";
@@ -23,15 +22,14 @@ export function PrivacyPolicy({ data, route }: PageProps<Data>) {
         path={path}
       />
       <div class="px-4">
-        <Section
-          level="1"
-          heading={translate("privacy_policy:heading")}
-          isContainer
-        >
-          <div class="mt-4">
+        <article class="reading">
+          <h1 class="m-0 font-logo font-extrabold text-h1 tracking-[-0.03em] leading-[1.05]">
+            {translate("privacy_policy:heading")}
+          </h1>
+          <div class="mt-9 text-muted [&_p]:text-[0.9375rem] [&_p]:leading-[1.85]">
             <RenderHTML html={data.widgetMap.privacy_policy} />
           </div>
-        </Section>
+        </article>
       </div>
     </DefaultAppShell>
   );


### PR DESCRIPTION
## Summary

- プライバシーポリシーページ（`/privacy_policy`）を editorial デザインへ更新
- 視覚のみ。コンテンツ取得・ハンドラ・i18n は不変（`domains/privacy/pages/PrivacyPolicy.tsx` の1ファイルのみ）

## 変更

- 汎用 `<Section>` ラッパーから **`.reading`（660px・中央寄せ）の本文カラム**へ変更
- display 見出し `<h1>`（`text-h1` / `font-logo` / `font-extrabold` / `tracking-[-0.03em]`）
- 本文ラッパーに `text-muted` ＋ `[&_p]:text-[0.9375rem] [&_p]:leading-[1.85]` を適用し、ポリシー本文を 15px / line-height 1.85 / muted（#9b9ba3）で表示。見出しは #ededee を維持
- 本文は従来どおり `RenderHTML` で描画（CMS の freeform HTML）

## 補足

- デザイン上の「番号付きセクション（番号カラム + 見出し + 本文のグリッド）」は適用していない。ポリシー本文はセクション番号を持たない freeform な HTML（h2/h3/h4 + p + ul）のため、見出し・本文のタイポグラフィでレイアウトを表現している

## Test plan

- [x] `deno fmt --check` / `deno lint` / 型チェック
- [x] `deno task build`
- [x] `deno task test` — 39 passed / 101 steps・回帰なし
- [x] ブラウザ実測（`/privacy_policy`）: `article.reading` = 660px 中央寄せ / `<h1>` 44px・weight 800 / 本文 15px・line-height 1.85・#9b9ba3（コントラスト 6.67:1）/ 見出し #ededee
- [ ] 目視（desktop + mobile 375px）

🤖 Generated with [Claude Code](https://claude.com/claude-code)