### PR TITLE
refactor(profile): extract shared social-links resource (S01)

### DIFF
--- a/shared/profile/social.ts
+++ b/shared/profile/social.ts
@@ -1,0 +1,29 @@
+import { translate } from "@shared/i18n/mod.ts";
+
+export type SocialItem = {
+  label: string;
+  name: string;
+  uri: string;
+};
+
+// Single source of truth for the profile's social links — consumed by the Home
+// rail and the footer colophon so the labels/handles/URIs can't drift apart.
+export function getSocialItems(): SocialItem[] {
+  return [
+    {
+      label: translate("social:github"),
+      name: translate("social:gitHubName"),
+      uri: "https://github.com/mya-ake",
+    },
+    {
+      label: translate("social:x"),
+      name: translate("social:xName"),
+      uri: "https://twitter.com/mya_ake",
+    },
+    {
+      label: translate("social:zenn"),
+      name: translate("social:zennName"),
+      uri: "https://zenn.dev/mya_ake",
+    },
+  ];
+}

--- a/shared/profile/social_test.ts
+++ b/shared/profile/social_test.ts
@@ -1,0 +1,22 @@
+import { describe, it } from "std/testing/bdd.ts";
+import { assertEquals } from "std/assert/mod.ts";
+import { getSocialItems } from "./social.ts";
+
+describe("getSocialItems", () => {
+  it("returns the three profile social links in order, with their URIs", () => {
+    assertEquals(
+      getSocialItems().map((item) => item.uri),
+      [
+        "https://github.com/mya-ake",
+        "https://twitter.com/mya_ake",
+        "https://zenn.dev/mya_ake",
+      ],
+    );
+  });
+
+  it("shapes every item with label, name, and uri fields", () => {
+    for (const item of getSocialItems()) {
+      assertEquals(Object.keys(item).sort(), ["label", "name", "uri"]);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- プロフィールのソーシャルリンク（GitHub / X / Zenn の label・handle・URI）を単一ソース化する共有リソースを追加
- モバイル対応の一連の更新の土台。Home とフッターで別々に重複していた定義を1か所に集約し、drift を防ぐ

## 変更

- **`shared/profile/social.ts`（新規）**: `getSocialItems(): SocialItem[]`（＋ `SocialItem` 型 `{ label; name; uri }`）。これまで `domains/home/pages/Home.tsx` と `shared/ui/app_shells/children/footer/DefaultFooter.tsx` にそれぞれローカル定義で重複していたソーシャルリンク（同じ i18n キー＋URI）を集約。依存は `@shared/i18n` のみ
- **`shared/profile/social_test.ts`（新規）**: URI 3件の順序と、各要素が `label`/`name`/`uri` を持つ構造を検証（`translate()` は i18n 未初期化のテスト環境で値が未定義になり得るため、ラベル値ではなく静的契約＝URI・形を対象）

## 補足

- 本 PR は共有リソースの**追加のみ**。既存の Home / フッターのローカル重複は、それぞれを本リソース利用へ移行する後続の変更で削除する（依存先に契約を先に置く構成）

## Test plan

- [x] `deno fmt --check` / `deno lint` / 型チェック
- [x] `deno task build`
- [x] `deno task test` — 40 passed / 103 steps（社会リンク用テスト +1・回帰なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)