### PR TITLE
refactor(footer): consume the shared social-links resource (S02)

### DIFF
--- a/shared/ui/app_shells/children/footer/DefaultFooter.tsx
+++ b/shared/ui/app_shells/children/footer/DefaultFooter.tsx
@@ -4,23 +4,8 @@ import { StyledInternalLink } from "../../../link/StyledInternalLink.tsx";
 import { RenderHTML } from "@shared/render/RenderHTML.tsx";
 import { PawMark } from "@shared/ui/icon/PawMark.tsx";
 import { Copyright } from "./children/Copyright.tsx";
+import { getSocialItems } from "@shared/profile/social.ts";
 import type { WidgetMap } from "@shared/widget/mod.ts";
-
-function getSocialItems(): { label: string; name: string; uri: string }[] {
-  return [{
-    label: translate("social:github"),
-    name: translate("social:gitHubName"),
-    uri: "https://github.com/mya-ake",
-  }, {
-    label: translate("social:x"),
-    name: translate("social:xName"),
-    uri: "https://twitter.com/mya_ake",
-  }, {
-    label: translate("social:zenn"),
-    name: translate("social:zennName"),
-    uri: "https://zenn.dev/mya_ake",
-  }];
-}
 
 export type Props = {
   widgetMap: WidgetMap<"footer_bio">;


### PR DESCRIPTION
## Summary

- フッター奥付のソーシャルリンクを、共有リソース `shared/profile/social.ts` 経由に変更
- フッター内に重複していたローカル定義を削除し、Home 側と単一ソースを共有（drift 防止）。表示は不変

## 変更

- **`shared/ui/app_shells/children/footer/DefaultFooter.tsx`**: ローカルの `getSocialItems()`（15行の重複定義）を削除し、`@shared/profile/social.ts` の `getSocialItems` を import に置換（+1 / -16）。Social セクションの描画ロジック・マークアップは不変。`translate` は見出し等で引き続き使用

## 補足

- 表示・レイアウトの変更なし。3件のソーシャルリンクは従来どおり描画され、奥付の3カラムグリッド（`md:grid-cols-[200px_1fr_auto]`）は `@media (min-width:768px)` でのみカラム化されるため、768px 未満では従来どおり1カラムに縦積みされる（mobile-first のまま）

## Test plan

- [x] `deno fmt --check` / `deno lint` / 型チェック
- [x] `deno task build`
- [x] `deno task test` — 40 passed / 103 steps・回帰なし
- [x] コンパイル CSS で確認: `.grid` は無条件のカラム指定なし／フッターの `grid-cols-[200px_1fr_auto]` は `@media (min-width:48rem)` 内 → 768px 未満は1カラム縦積み。デスクトップ（≥768px）は 200px/1fr/auto を維持・ソーシャル3件描画
- [ ] 実機 375px での目視（リリース前）

🤖 Generated with [Claude Code](https://claude.com/claude-code)