### PR TITLE
feat(design): editorial sub-page header + masthead mobile wrap (S03)

### DIFF
--- a/shared/ui/app_shells/children/header/BasicHeader.tsx
+++ b/shared/ui/app_shells/children/header/BasicHeader.tsx
@@ -2,22 +2,47 @@ import { InternalLink } from "@shared/ui/link/InternalLink.tsx";
 import { Logo } from "@shared/symbol/Logo.tsx";
 import type { ComponentChildren } from "preact";
 
+export type HeaderNavItem = {
+  label: string;
+  href: string;
+  current: boolean;
+};
+
 type Props = {
+  nav?: HeaderNavItem[];
   children?: ComponentChildren;
 };
 
-export function BasicHeader(props: Props) {
+// Sub-page header (lower pages): editorial wordmark on the left, a small mono
+// section nav on the right, above the breadcrumb row passed as children. The row
+// wraps on narrow screens; the active nav item is shown in the primary text tone.
+export function BasicHeader({ nav, children }: Props) {
   return (
-    <header>
-      <div class="text-center mt-4">
+    <header class="app-container px-4 pt-6">
+      <div class="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
         <InternalLink
           href="/"
-          class="leading-none text-2xl text-inherit no-underline"
+          class="block font-logo font-bold text-2xl tracking-[-0.02em] leading-none text-inherit no-underline"
         >
           <Logo />
         </InternalLink>
+        {nav && nav.length > 0 && (
+          <nav class="flex gap-[18px] font-mono text-xs">
+            {nav.map(({ label, href, current }) => (
+              <InternalLink
+                key={href}
+                href={href}
+                class={current
+                  ? "no-underline text-text"
+                  : "no-underline text-muted"}
+              >
+                {label}
+              </InternalLink>
+            ))}
+          </nav>
+        )}
       </div>
-      {props.children}
+      {children}
     </header>
   );
 }

--- a/shared/ui/app_shells/children/header/DefaultHeader.tsx
+++ b/shared/ui/app_shells/children/header/DefaultHeader.tsx
@@ -1,4 +1,4 @@
-import { BasicHeader } from "./BasicHeader.tsx";
+import { BasicHeader, type HeaderNavItem } from "./BasicHeader.tsx";
 import { InternalLink } from "@shared/ui/link/InternalLink.tsx";
 import { Logo } from "@shared/symbol/Logo.tsx";
 import { shouldShowMasthead } from "./should_show_masthead.ts";
@@ -17,7 +17,7 @@ export function DefaultHeader(props: Props) {
   if (shouldShowMasthead(props.breadcrumbs)) {
     return (
       <header class="app-container px-4 pt-10">
-        <div class="flex items-end justify-between gap-6">
+        <div class="flex flex-wrap items-end justify-between gap-x-6 gap-y-2">
           <InternalLink
             href="/"
             class="block text-inherit no-underline text-masthead font-extrabold tracking-[-0.04em] leading-[0.9]"
@@ -39,8 +39,17 @@ export function DefaultHeader(props: Props) {
     );
   }
 
+  // The section nav highlights "Posts" whenever the breadcrumb trail passes
+  // through /posts (the list and every article); Home is never current here
+  // because Home renders the masthead instead.
+  const isPostsSection = props.breadcrumbs.some((item) => item.to === "/posts");
+  const nav: HeaderNavItem[] = [
+    { label: "Home", href: "/", current: false },
+    { label: "Posts", href: "/posts", current: isPostsSection },
+  ];
+
   return (
-    <BasicHeader>
+    <BasicHeader nav={nav}>
       <div class="mt-4 border-y border-rule py-2">
         <Breadcrumbs items={props.breadcrumbs} />
       </div>


### PR DESCRIPTION
## Summary

- 下層ページ（Home 以外）のヘッダーを editorial デザインへ更新。これまで Home のマストヘッドのみ editorial 化され、**下層ヘッダーは旧デザイン（中央寄せの小ワードマーク）のまま**残っていた箇所を揃える
- あわせて Home マストヘッドの上段（ワードマーク＋タグライン）を狭幅で折り返せるよう調整

## 変更

- **`shared/ui/app_shells/children/header/BasicHeader.tsx`**: 下層ヘッダーを editorial レイアウトに刷新 — 中央寄せの小ワードマークから、**左にワードマーク（`font-logo` / 24px / bold）＋右に小さな mono のセクションナビ**の横並びへ。任意の `nav?: HeaderNavItem[]`（`{ label, href, current }`）を追加し、各項目を `InternalLink` で描画（`current` は `text-text`、非アクティブは `text-muted`）。ナビ行は `flex-wrap` で狭幅時に折り返す。breadcrumb 行（`children`）は従来どおり下に描画。`nav` は**任意**のため、ナビを渡さない呼び出し（エラーページ）はワードマークのみを表示
- **`shared/ui/app_shells/children/header/DefaultHeader.tsx`**: 下層分岐でナビを構築 — `breadcrumbs` が `/posts` を含むかで Posts のアクティブを判定（一覧・各記事で Posts がアクティブ。Home は常に非アクティブ＝Home はマストヘッドを描画するため）。マストヘッド分岐の上段を `flex-wrap` ＋ `gap-x`/`gap-y` に変更し、狭幅で折り返すように（デスクトップのレイアウトは不変）

## 補足

- 視覚のみ。ルーティング・データ取得・i18n は不変
- ナビのラベルは英語リテラル（"Home" / "Posts"）。breadcrumb 側は従来どおり i18n 名を使用
- エラーページ（`SimpleAppShell` → `BasicHeader`・ナビなし）は、中央寄せから左寄せのワードマーク表示に変わる（軽微・許容）
- ナビの非アクティブ項目は `text-muted`（#9b9ba3・コントラスト 4.5:1 以上）

## Test plan

- [x] `deno fmt --check` / `deno lint` / 型チェック（`SimpleAppShell` 含む・`nav` 任意）
- [x] `deno task build`
- [x] `deno task test` — 40 passed / 103 steps・回帰なし
- [x] ブラウザ実測（desktop ~1464px）: ヘッダー 920px 中央寄せ / ワードマーク 24px・bold 左端 / ナビ右端（Posts アクティブ=#ededee, Home=#9b9ba3）/ breadcrumb 罫が 888px（920 コンテナ内）に整列
- [x] ナビのアクティブ表示をルート別に確認: `/posts`・記事=Posts アクティブ、`/privacy_policy`=両方非アクティブ
- [x] ナビ行・マストヘッド上段の折返しは `flex-wrap`（computed `flex-wrap: wrap`）で構造確認
- [ ] 実機 375px での目視（ヘッダー折返し・リリース前）

🤖 Generated with [Claude Code](https://claude.com/claude-code)