### PR TITLE
fix(design): keep web-font <link> on article pages (Fresh head dedup)

### DIFF
--- a/routes/_app.tsx
+++ b/routes/_app.tsx
@@ -19,11 +19,19 @@ export default function App({ Component }: PageProps) {
           href="https://fonts.gstatic.com"
           crossOrigin="anonymous"
         />
+        {
+          /* Unique `key`s keep these static stylesheets from colliding with
+            <Head>-injected <link rel="stylesheet"> (e.g. HighlightJSHead on
+            article pages): Fresh's head dedup ignores `href`, so every
+            rel="stylesheet" otherwise shares one cacheKey and the later one
+            replaces the earlier — which dropped the web-font link on /posts/:id. */
+        }
         <link
+          key="gfonts"
           href="https://fonts.googleapis.com/css2?family=Schibsted+Grotesk:wght@400;500;600;700;800&family=Noto+Sans+JP:wght@400;500;700&family=JetBrains+Mono:wght@400;500&display=swap"
           rel="stylesheet"
         />
-        <link rel="stylesheet" href="/styles.css" />
+        <link key="app-styles" rel="stylesheet" href="/styles.css" />
         {gaTagId && (
           <script
             async


### PR DESCRIPTION
## Summary

- `/posts/:id`（記事ページ）で Web フォント（Schibsted Grotesk / Noto Sans JP / JetBrains Mono）が読み込まれず、ワードマーク・ナビ・見出し・本文が system フォントにフォールバックしていた不具合を修正
- 原因は Fresh の `<Head>` 重複排除（dedup）が `<link>` の `href` を無視して全 `rel="stylesheet"` を1つの cacheKey に集約すること。記事ページで `HighlightJSHead` が `<Head>` 経由で注入する stylesheet `<link>` が、`_app.tsx` の Google Fonts `<link>` を置換して消していた（`styles.css` は同 cacheKey 消費後で生き残る）

## 変更

- **`routes/_app.tsx`**: 静的な stylesheet `<link>` 2つ（Google Fonts / `/styles.css`）にそれぞれ一意の `key`（`gfonts` / `app-styles`）を付与。`key` を付けると各リンクの cacheKey がその値になり、`<Head>` 経由で注入される stylesheet と衝突しなくなる（highlight.js の CSS は置換ではなく追加で出力される）。意図を説明するコメントも追加（+9 / -1）

## 補足

- 視覚のみ。ルーティング・データ取得・i18n は不変
- 記事以外（Home / 一覧 / プライバシー）は `HighlightJSHead` を使わないため元からフォントは正常で、本修正による影響なし
- `key` は描画 HTML 上 `data-key="…"` 属性として出力される（Fresh の通常挙動・無害）

## Test plan

- [x] `deno fmt --check` / `deno lint` / 型チェック
- [x] `deno task build`
- [x] `deno task test` — 回帰なし（`MICRO_CMS_*` env 下で green）
- [x] 描画 HTML 確認（`deno task preview`）: 記事 `/posts/:id` の `<head>` に Google Fonts・highlight.js・`/styles.css` の3つの stylesheet が共存（font link 復活）。Home / `/posts` / `/privacy_policy` は Google Fonts + `/styles.css` のみで highlight CSS なし（回帰なし）
- [ ] ブラウザ実機での目視（記事ページのフォント表示・リリース前）

🤖 Generated with [Claude Code](https://claude.com/claude-code)