### PR TITLE
feat(design): mobile-responsive Home — card strip + 1-col GitHub (S04)

### DIFF
--- a/domains/home/pages/Home.tsx
+++ b/domains/home/pages/Home.tsx
@@ -8,30 +8,9 @@ import { translate } from "@shared/i18n/mod.ts";
 import { SEOHead } from "@shared/head/SEOHead.tsx";
 import { RenderHTML } from "@shared/render/RenderHTML.tsx";
 import { createBreadcrumbs } from "@shared/breadcrumbs/manager.ts";
+import { getSocialItems } from "@shared/profile/social.ts";
 import type { PageProps } from "fresh";
 import type { Data } from "./Home.handler.ts";
-
-// Same source as the footer colophon; kept local until a shared profile resource
-// is extracted (follow-up — see DefaultFooter.getSocialItems).
-function getSocialItems(): { label: string; name: string; uri: string }[] {
-  return [
-    {
-      label: translate("social:github"),
-      name: translate("social:gitHubName"),
-      uri: "https://github.com/mya-ake",
-    },
-    {
-      label: translate("social:x"),
-      name: translate("social:xName"),
-      uri: "https://twitter.com/mya_ake",
-    },
-    {
-      label: translate("social:zenn"),
-      name: translate("social:zennName"),
-      uri: "https://zenn.dev/mya_ake",
-    },
-  ];
-}
 
 export function Home({ data }: PageProps<Data>) {
   const socialItems = getSocialItems();
@@ -50,28 +29,44 @@ export function Home({ data }: PageProps<Data>) {
 
         <div class="grid gap-12 md:grid-cols-[200px_1fr]">
           {/* Left rail — profile + social */}
-          <aside aria-label={translate("profile:heading")}>
+          <aside
+            aria-label={translate("profile:heading")}
+            class="flex items-center gap-3 rounded-xl border border-rule bg-surface p-3 md:block md:gap-0 md:rounded-none md:border-0 md:bg-transparent md:p-0"
+          >
             <img
               src="/assets/v3/images/avatar.jpg"
               width="60"
               height="60"
-              class="rounded-full"
+              class="rounded-full shrink-0"
               alt=""
             />
-            <p class="mt-4 font-logo text-xl">
-              {translate("profile:nameWithYomi")}
-            </p>
-            <ul class="mt-6 grid gap-2 list-none p-0 font-mono text-[0.78rem]">
-              {socialItems.map(({ label, name, uri }) => (
-                <li
-                  key={uri}
-                  class="flex justify-between gap-3 border-b border-hairline pb-[7px]"
-                >
-                  <span class="text-muted">{label}</span>
-                  <StyledExternalLink href={uri}>@{name}</StyledExternalLink>
-                </li>
-              ))}
-            </ul>
+            <div class="min-w-0 md:contents">
+              <p class="font-logo text-base md:mt-4 md:text-xl">
+                {translate("profile:nameWithYomi")}
+              </p>
+              <ul class="mt-1 flex flex-wrap gap-x-3 gap-y-1 list-none p-0 font-mono text-xs md:mt-6 md:grid md:gap-2">
+                {socialItems.map(({ label, name, uri }) => (
+                  <li
+                    key={uri}
+                    class="flex items-center md:justify-between md:gap-3 md:border-b md:border-hairline md:pb-[7px]"
+                  >
+                    <StyledExternalLink
+                      href={uri}
+                      class="md:hidden text-muted"
+                    >
+                      {label}
+                    </StyledExternalLink>
+                    <span class="hidden md:inline text-muted">{label}</span>
+                    <StyledExternalLink
+                      href={uri}
+                      class="hidden md:inline text-link"
+                    >
+                      @{name}
+                    </StyledExternalLink>
+                  </li>
+                ))}
+              </ul>
+            </div>
           </aside>
 
           {/* Right column — numbered editorial index */}
@@ -128,11 +123,11 @@ export function Home({ data }: PageProps<Data>) {
                   ({ id, name, html_url, description }) => (
                     <li
                       key={id}
-                      class="grid grid-cols-[140px_1fr] gap-4 border-t border-hairline py-3"
+                      class="grid grid-cols-1 gap-1 md:grid-cols-[140px_1fr] md:gap-4 border-t border-hairline py-3"
                     >
                       <StyledExternalLink
                         href={html_url}
-                        class="font-mono text-link text-[0.84rem]"
+                        class="font-mono text-link text-sm"
                       >
                         {name}
                       </StyledExternalLink>


### PR DESCRIPTION
## Summary

- Home ページ（`/`）をモバイル対応（editorial デザイン）に。desktop（≥768px）のレイアウト・構造は不変で、モバイル（<768px）の表示を整える
- あわせてプロフィールのソーシャルリンクを共有リソース `@shared/profile/social.ts` 経由に統一し、Home 内のローカル重複定義を削除（フッターと単一ソース化）

## 変更

- **`domains/home/pages/Home.tsx`**（+35 / -40）
  - プロフィール rail を**モバイルでは名刺帯**（avatar + 名前 + Social ラベルの横並びカード: `bg-surface` / `rounded-xl` / `border`）に再構成。`min-w-0 md:contents` ラッパで、desktop は従来の縦積み rail を `md:` 上書きで復元
  - **Social**: モバイル = ラベルのみのリンク（GitHub / X / Zenn、各プロフィールへ遷移）、desktop = 従来の `label` + `@name` 行（`md:` で表示切替。`@handle` はフッターの奥付にも掲載）
  - **GitHub** リポジトリ一覧: モバイルは1カラム（`grid-cols-1`）、desktop は `md:grid-cols-[140px_1fr]` を維持
  - ソーシャルリンクを `@shared/profile/social.ts` の `getSocialItems` から取得（ローカル重複定義を削除）
  - off-scale な arbitrary サイズをスケールトークンへ正規化: Social `text-[0.78rem]` → `text-xs`、GitHub リポ名 `text-[0.84rem]` → `text-sm`

## 補足

- additive な変更（base = モバイル + `md:` = desktop 上書き）。desktop の構造・配色は不変で、desktop に影響する変更は上記2つの型サイズ正規化（いずれも <0.6px、隣接要素のスケールに合わせる意図）のみ
- `StyledExternalLink` は consumer の `class` がデフォルトの `text-link` を**置換**するため、desktop の `@name` リンクには `text-link` を明示的に付与

## Test plan

- [x] `deno fmt --check` / `deno lint` / 型チェック（`as` 不使用）
- [x] `deno task build`
- [x] `deno task test` — 回帰なし（`MICRO_CMS_*` env 下で green）
- [x] コンパイル CSS の構造確認: `md:grid-cols-[200px_1fr]` / `md:grid-cols-[140px_1fr]` などの desktop 変種は `@media (min-width:48rem)` 内に限定、`grid-cols-1` と名刺帯ユーティリティは base（unprefixed）→ モバイルファースト
- [x] desktop 実測（~1464px）: 200px rail・GitHub `[140px_1fr]`・numbered sections が不変
- [ ] 実機 375px での目視（名刺帯の折返し・ラベルリンク・GitHub 縦積み・リリース前）

🤖 Generated with [Claude Code](https://claude.com/claude-code)