### PR TITLE
feat(design): tighten Posts year-grid gap on mobile (S05)

### DIFF
--- a/domains/post/pages/list/Posts.tsx
+++ b/domains/post/pages/list/Posts.tsx
@@ -36,7 +36,7 @@ export function Posts({ data }: PageProps<Data>) {
           {groups.map(({ year, posts }) => (
             <div
               key={year}
-              class="grid grid-cols-[auto_1fr] gap-8 border-t border-rule pt-3 pb-6 md:grid-cols-[120px_1fr]"
+              class="grid grid-cols-[auto_1fr] gap-4 border-t border-rule pt-3 pb-6 md:grid-cols-[120px_1fr] md:gap-8"
             >
               <div class="pt-1.5 font-mono text-[1.875rem] font-medium leading-none tracking-[-0.02em] text-faint">
                 {year}


### PR DESCRIPTION
## Summary

- 記事一覧（`/posts`）の年別アーカイブのグリッド列ギャップをモバイルで詰め、狭い画面でタイトル列が窮屈にならないようにする
- 全幅で 32px だった列ギャップ（`gap-8`）を、モバイルは 16px・`md:`（≥768px）以上は従来どおり 32px に

## 変更

- **`domains/post/pages/list/Posts.tsx`**: 年グループのグリッドを `gap-8` → `gap-4 md:gap-8`。年マーカー列（desktop は `md:grid-cols-[120px_1fr]`）は不変。モバイルで列ギャップが 16px になり、各行のタイトルリンクの実効幅が広がる（375px で約 171px → 約 187px）。desktop（≥768px）のレイアウトは不変

## 補足

- additive な変更（base = モバイル + `md:` = desktop 上書き）
- 記事詳細（`/posts/:id`）とプライバシー（`/privacy_policy`）は `.reading`（最大 660px・中央寄せ）が `px-4` 内で全幅に縮むため、すでにモバイルで適切に読める状態を確認。これらは変更なし

## Test plan

- [x] `deno fmt --check` / `deno lint` / 型チェック（`as` 不使用）
- [x] `deno task build`
- [x] `deno task test` — 回帰なし（`MICRO_CMS_*` env 下で green）
- [x] コンパイル CSS の構造確認: `.gap-4` は base（unprefixed・モバイル 16px）、`.md:gap-8` と `.md:grid-cols-[120px_1fr]` は `@media (min-width:48rem)` 内（desktop 32px・120px 列）→ gap 変更はモバイル限定で desktop 不変
- [ ] 実機 375px での目視（`/posts` の年・日付・タイトルが潰れず折り返すか・リリース前）

🤖 Generated with [Claude Code](https://claude.com/claude-code)