### PR TITLE
feat(posts): fetch all posts via offset pagination (S06)

### DIFF
--- a/domains/post/pages/list/Posts.handler.ts
+++ b/domains/post/pages/list/Posts.handler.ts
@@ -6,8 +6,7 @@ import {
   DefaultAppShellWidgetMap,
   getDefaultAppShellWidgetMap,
 } from "@shared/ui/app_shells/services/default_app_shell_wedgets.ts";
-import { getPosts as getPostsFromCMS, Posts } from "@shared/post/list.ts";
-import { decidePublishedAt } from "@post/shared/decide_published_at.ts";
+import { getAllPosts as getPostsFromCMS, Posts } from "@shared/post/list.ts";
 import { pageCacheHeaders } from "@shared/middleware/cache.ts";
 
 export type Data = {
@@ -15,24 +14,15 @@ export type Data = {
   widgetMap: DefaultAppShellWidgetMap;
 };
 
+// The archive renders every published post grouped by year, so fetch the whole
+// list (offset pagination handles counts beyond MicroCMS's 100/request cap).
 const getPosts = getUseMicroCMSCache()
   ? createInstantCache("posts")(getPostsFromCMS)
   : getPostsFromCMS;
 
-// The archive renders every published post grouped by year, so fetch the whole
-// list in one request. MicroCMS caps `limit` at 100/request; the post count is
-// well under that, so a single raised-limit request is enough (paginate-all is
-// deferred until the count approaches 100 — see stack Follow-ups).
-const POSTS_ARCHIVE_LIMIT = 100;
-
 export const handler = {
   async GET(_ctx: Context<unknown>) {
-    const postsData = await getPosts({ limit: POSTS_ARCHIVE_LIMIT }).then(
-      (posts) => ({
-        ...posts,
-        contents: posts.contents.map(decidePublishedAt),
-      }),
-    );
+    const postsData = await getPosts();
     const widgetMap = await getDefaultAppShellWidgetMap();
     const data: Data = {
       posts: postsData,

--- a/shared/post/list.ts
+++ b/shared/post/list.ts
@@ -4,6 +4,7 @@ import { getUsePostsFilter } from "@shared/env/mod.ts";
 import { decidePublishedAt } from "@post/shared/decide_published_at.ts";
 
 import type {
+  Content,
   MicroCMSList,
   Post as OriginalPost,
   Tag as OriginalTag,
@@ -32,13 +33,45 @@ export type GetPostOption = {
   limit?: number;
 };
 
-export function getPosts(option?: GetPostOption): Promise<Posts> {
+// MicroCMS caps `limit` at 100 items per request.
+const PAGE_SIZE = 100;
+
+/**
+ * Fetches every item of a MicroCMS list by offset pagination — page 0, then the
+ * running count, and so on, until `contents.length === totalCount`. Pure and
+ * injectable: the caller supplies the per-offset page fetcher, so this has no
+ * dependency on the client or env (and is unit-testable without either). Stops
+ * defensively if a page comes back empty while more were expected, so a
+ * malformed response cannot loop forever.
+ */
+export async function paginateAll<
+  // deno-lint-ignore no-explicit-any
+  C extends Content<any>,
+>(
+  fetchPage: (offset: number) => Promise<MicroCMSList<C>>,
+): Promise<MicroCMSList<C>> {
+  const first = await fetchPage(0);
+  const contents: C[] = [...first.contents];
+  while (contents.length < first.totalCount) {
+    const page = await fetchPage(contents.length);
+    if (page.contents.length === 0) break;
+    contents.push(...page.contents);
+  }
+  return { ...first, contents, offset: 0, limit: first.totalCount };
+}
+
+function fetchPostsPage(
+  params: { limit: number; offset?: number },
+): Promise<Posts> {
   const client = getMicroCmsClient();
   return client.get<Posts>({
     resource: "posts",
     fields,
     orders: "-publishedAt",
-    limit: option?.limit ?? 10,
+    limit: params.limit,
+    // Only send `offset` when set, so `getPosts` keeps its original request URL
+    // (the client serializes every key, including an explicit `undefined`).
+    ...(params.offset === undefined ? {} : { offset: params.offset }),
     filters: getUsePostsFilter() ? "tags[contains]post" : "",
   }).then((data) => {
     return {
@@ -46,4 +79,14 @@ export function getPosts(option?: GetPostOption): Promise<Posts> {
       contents: data.contents.map(decidePublishedAt),
     };
   });
+}
+
+export function getPosts(option?: GetPostOption): Promise<Posts> {
+  return fetchPostsPage({ limit: option?.limit ?? 10 });
+}
+
+export function getAllPosts(): Promise<Posts> {
+  return paginateAll<DisplayPost>((offset) =>
+    fetchPostsPage({ limit: PAGE_SIZE, offset })
+  );
 }

--- a/shared/post/list_test.ts
+++ b/shared/post/list_test.ts
@@ -1,0 +1,111 @@
+import { describe, it } from "std/testing/bdd.ts";
+import { assertEquals } from "std/assert/mod.ts";
+import { paginateAll } from "./list.ts";
+import type { MicroCMSList } from "@shared/micro_cms/type.ts";
+
+type Item = {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  publishedAt: string;
+  revisedAt: string;
+};
+
+const item = (id: string): Item => ({
+  id,
+  createdAt: "",
+  updatedAt: "",
+  publishedAt: "",
+  revisedAt: "",
+});
+
+const range = (n: number): Item[] =>
+  Array.from({ length: n }, (_, i) => item(String(i)));
+
+const ids = (list: { id: string }[]): string[] => list.map((c) => c.id);
+
+// Records the offsets it is asked for and returns the matching slice of `all`
+// with `totalCount` derived from the full list — mirroring the real MicroCMS
+// list envelope so the mock matches the dependency contract.
+function makeFetchPage(all: Item[], pageSize: number) {
+  const offsets: number[] = [];
+  const fetchPage = (offset: number): Promise<MicroCMSList<Item>> => {
+    offsets.push(offset);
+    return Promise.resolve({
+      contents: all.slice(offset, offset + pageSize),
+      totalCount: all.length,
+      offset,
+      limit: pageSize,
+    });
+  };
+  return { fetchPage, offsets };
+}
+
+describe("paginateAll", () => {
+  it("fetches a single page when totalCount is below the page size", async () => {
+    const all = range(7);
+    const { fetchPage, offsets } = makeFetchPage(all, 100);
+
+    const result = await paginateAll(fetchPage);
+
+    assertEquals(offsets, [0]);
+    assertEquals(ids(result.contents), ids(all));
+    assertEquals(result.totalCount, 7);
+    assertEquals(result.offset, 0);
+    assertEquals(result.limit, 7);
+  });
+
+  it("stops after one page when totalCount equals the page size", async () => {
+    const all = range(100);
+    const { fetchPage, offsets } = makeFetchPage(all, 100);
+
+    const result = await paginateAll(fetchPage);
+
+    // No second request at offset 100 — the loop ends once everything is in.
+    assertEquals(offsets, [0]);
+    assertEquals(result.contents.length, 100);
+    assertEquals(ids(result.contents), ids(all));
+  });
+
+  it("pages through offsets until every item is fetched", async () => {
+    const all = range(250);
+    const { fetchPage, offsets } = makeFetchPage(all, 100);
+
+    const result = await paginateAll(fetchPage);
+
+    assertEquals(offsets, [0, 100, 200]);
+    assertEquals(result.contents.length, 250);
+    assertEquals(ids(result.contents), ids(all));
+    assertEquals(result.offset, 0);
+    assertEquals(result.limit, 250);
+  });
+
+  it("returns an empty list when there are no items", async () => {
+    const { fetchPage, offsets } = makeFetchPage([], 100);
+
+    const result = await paginateAll(fetchPage);
+
+    assertEquals(offsets, [0]);
+    assertEquals(result.contents, []);
+    assertEquals(result.totalCount, 0);
+  });
+
+  it("stops defensively when a page is empty before totalCount is reached", async () => {
+    const available = range(3);
+    const offsets: number[] = [];
+    const fetchPage = (offset: number): Promise<MicroCMSList<Item>> => {
+      offsets.push(offset);
+      return Promise.resolve({
+        contents: available.slice(offset, offset + 100),
+        totalCount: 5, // claims more than is actually returnable
+        offset,
+        limit: 100,
+      });
+    };
+
+    const result = await paginateAll(fetchPage);
+
+    assertEquals(offsets, [0, 3]);
+    assertEquals(result.contents.length, 3);
+  });
+});


### PR DESCRIPTION
## Summary

- 記事一覧（`/posts`）が全公開記事を取得するよう、オフセットページネーションを導入。従来は1リクエスト（`limit: 100`）で取得しており、記事数が 100 を超えると取りこぼしが発生していた
- ページネーションのロジックにユニットテストを追加

## 変更

- **`shared/post/list.ts`**
  - 純粋・注入可能な `paginateAll`（`contents.length === totalCount` までオフセットでループ、空ページが返ったら防御的に停止）を追加
  - リクエスト設定を private な `fetchPostsPage` に集約し、`getPosts`（シグネチャ・挙動不変）と新規 `getAllPosts`（全件取得）が共有
- **`domains/post/pages/list/Posts.handler.ts`**: `/posts` ハンドラを `getAllPosts` に変更。`POSTS_ARCHIVE_LIMIT` 定数と、ヘルパー側で既に適用済みの冗長な2回目の `decidePublishedAt` map（および未使用 import）を削除
- **`shared/post/list_test.ts`（新規）**: `paginateAll` を5ケース（単一ページ / 100 件ちょうどの境界 / 複数ページ / 空 / ページが空になった際の防御的停止）で検証。ページ取得関数を注入する fake を使い、MicroCMS・env・ネットワークに非依存

## 補足

- `getPosts` の公開シグネチャ・挙動は不変（他の呼び出し元に影響なし）。`offset` は値がある時のみリクエストに含め、`getPosts` の元のリクエスト URL を厳密に維持
- `getAllPosts` は全記事を `contents` に、実際の総数を `totalCount` に持つ `MicroCMSList` を返すため、一覧の「全 N 記事」表示と年別グルーピングは従来どおり動作

## Test plan

- [x] `deno fmt --check` / `deno lint` / 型チェック（`as` 不使用）
- [x] `deno task build`
- [x] `deno task test` — 40 passed（新規 `paginateAll` テスト5ケースを含む）。`MICRO_CMS_*` env 下で回帰なし
- [x] `paginateAll` ユニットテスト: 単一→offsets `[0]` / 100 件→`[0]`（offset 100 で再取得しない）/ 250 件→`[0, 100, 200]` / 空→`[0]` / 防御的停止→`[0, 3]`（無限ループなし）。各ケースで要求 offset・結合結果・順序を検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)