### PR TITLE
perf(design): drop unused Schibsted Grotesk weight 600 (S07)

### DIFF
--- a/routes/_app.tsx
+++ b/routes/_app.tsx
@@ -28,7 +28,7 @@ export default function App({ Component }: PageProps) {
         }
         <link
           key="gfonts"
-          href="https://fonts.googleapis.com/css2?family=Schibsted+Grotesk:wght@400;500;600;700;800&family=Noto+Sans+JP:wght@400;500;700&family=JetBrains+Mono:wght@400;500&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Schibsted+Grotesk:wght@400;500;700;800&family=Noto+Sans+JP:wght@400;500;700&family=JetBrains+Mono:wght@400;500&display=swap"
           rel="stylesheet"
         />
         <link key="app-styles" rel="stylesheet" href="/styles.css" />


### PR DESCRIPTION
## Summary

- Google Fonts の `<link>` から未使用の Schibsted Grotesk weight 600（semibold）を削除し、使われていないウェイトのダウンロードをやめる

## 変更

- **`routes/_app.tsx`**: Google Fonts URL の `Schibsted+Grotesk:wght@400;500;600;700;800` → `400;500;700;800`（600 を削除）
  - `font-semibold`（= weight 600）はコードベースで未使用で、`static/styles.css` にも `font-weight: 600` の指定は無い
  - Noto Sans JP（`400;500;700`）と JetBrains Mono（`400;500`）のレンジは不変
  - `<link>` の `key` 属性は維持。Fresh の `<Head>` 重複排除は `<link>` を `rel` で識別し `href` を無視するため、`key` が無いと記事ページで `HighlightJSHead` 注入の stylesheet に置換され、Web フォントが落ちる

## Test plan

- [x] `deno fmt --check` / `deno lint` / 型チェック
- [x] `deno task build`
- [x] `deno task test` — 40 passed・回帰なし（`MICRO_CMS_*` env 下）
- [x] 描画 HTML 確認: 記事 `/posts/:id` の `<head>` に font `<link>`（`data-key="gfonts"`）が highlight.js CSS と共存し、Schibsted のレンジが `400;500;700;800`（600 削除）であること。Home も同様
- [ ] 全ウェイト（400 / 500 / 700 / 800）の実描画目視（リリース前）

🤖 Generated with [Claude Code](https://claude.com/claude-code)