### PR TITLE
feat(design): update masthead tagline copy

### DIFF
--- a/shared/ui/app_shells/children/header/DefaultHeader.tsx
+++ b/shared/ui/app_shells/children/header/DefaultHeader.tsx
@@ -25,7 +25,7 @@ export function DefaultHeader(props: Props) {
             <Logo />
           </InternalLink>
           <p class="m-0 shrink-0 text-right font-mono text-muted text-[0.6875rem] tracking-[0.16em] leading-[1.8]">
-            Cat-loving<br />Web Engineer
+            Notes on Code<br />& Curiosity
           </p>
         </div>
         <div class="masthead-rule mt-[1.375rem]" />


### PR DESCRIPTION
## Summary

- Home のマストヘッドのタグラインの文言を更新する

## 変更

- **`shared/ui/app_shells/children/header/DefaultHeader.tsx`**: マストヘッドのタグラインを `Cat-loving` / `Web Engineer` から `Notes on Code` / `& Curiosity` に変更（2行・`<br />` 改行、mono のスタイルは不変）

## Test plan

- [x] `deno fmt --check` / `deno lint` / 型チェック
- [ ] 目視（マストヘッドのタグライン表示・desktop / 375px）

🤖 Generated with [Claude Code](https://claude.com/claude-code)