### PR TITLE
chore(deno): upgrade runtime 2.7.2 → 2.8.3 across image and CI

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v2.7.2
+          deno-version: v2.8.3
       - name: Lint
         run: deno lint
       - name: Check format

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v2.7.2
+          deno-version: v2.8.3
       - name: Lint
         run: deno lint
       - name: Check format

--- a/.github/workflows/update-sitemap.yml
+++ b/.github/workflows/update-sitemap.yml
@@ -15,6 +15,6 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v2.7.2
+          deno-version: v2.8.3
       - name: Fetch sitemap
         run: deno run --allow-net scripts/fetch_sitemap.ts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM denoland/deno:2.7.2
+FROM denoland/deno:2.8.3
 
 EXPOSE 8000
 


### PR DESCRIPTION
## Summary

- Deno ランタイムの pin を 2.7.2 → 2.8.3（最新 stable）へ更新する。本番イメージと CI が同一ランタイムで揃うよう、リポジトリ内の 4 箇所すべてを同時に更新

## 変更

- **`Dockerfile`**: `FROM denoland/deno:2.7.2` → `2.8.3`（本番ランタイム）
- **`.github/workflows/ci-push.yml` / `ci-pr.yml` / `update-sitemap.yml`**: `denoland/setup-deno` の `deno-version: v2.7.2` → `v2.8.3`
- リポジトリ内の `2.7.2` 参照はこの 4 箇所のみ。アプリコード・`deno.jsonc`（ライブラリ依存）・テストの変更はなし（4 files / +4 -4）

## 補足

- CI の `deno-version` pin と Dockerfile の `FROM` を一致させることで、CI が検証するランタイムと本番がビルド・実行するランタイムが揃う
- Deno 2.8 系の主な変更（TypeScript 6.0.3、Node 互換タイマー型をデフォルト化、V8 14.9 など）は型検査面の変更だが、`deno check` / `deno task build` が 2.8.3 で通り、本コードベースへの影響がないことを確認

## Test plan

- [x] `deno fmt --check`（170 files・リフローなし）/ `deno lint`（156 files・新規指摘なし）
- [x] `deno check`（`*.ts`/`*.tsx`、`_fresh/` 除外）
- [x] `deno task build`（Dockerfile が実行する本番ビルド）
- [x] `deno task test` — 既存の `MicroCmsClient` ネットワークテスト 1 件は live endpoint 非依存環境での既知の失敗（本変更とは無関係。変更した 4 ファイルはテストから参照されない）。他は green

🤖 Generated with [Claude Code](https://claude.com/claude-code)