### PR TITLE
build(docker): digest-pin the deno 2.8.3 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM denoland/deno:2.8.3
+# Pinned by digest for reproducible, tamper-evident builds. The :2.8.3 tag is kept
+# for readability; the digest is the multi-arch index for that tag. When bumping the
+# version, update BOTH the tag and the digest (e.g. `docker buildx imagetools inspect
+# denoland/deno:<version>`, or the registry manifest digest).
+FROM denoland/deno:2.8.3@sha256:438618d8c0678c3154fc77ad6edad61f38cbc42803a181e7908d3e2c9e645022
 
 EXPOSE 8000
 


### PR DESCRIPTION
## Summary

- 本番 Docker ベースイメージ `denoland/deno:2.8.3` をダイジェストで pin し、イメージのビルドを再現可能・改ざん検知可能にする

## 変更

- **`Dockerfile`**: `FROM denoland/deno:2.8.3` → `FROM denoland/deno:2.8.3@sha256:438618d8c0678c3154fc77ad6edad61f38cbc42803a181e7908d3e2c9e645022`
  - ダイジェストは `denoland/deno:2.8.3` タグの**マルチアーキ index（manifest list）digest**。index を pin するため、ビルド時のマルチアーキ解決は維持される
  - 可読性のためタグ `:2.8.3` は残置（イメージの取得元・namespace は不変で、解決のみを固定）
  - version bump 時にタグと digest を両方更新する旨の保守コメントを追加

## 補足

- アプリコード・`deno.jsonc`・CI ワークフローの変更はなし（`Dockerfile` のみ / +5 -1）

## Test plan

- [x] `deno fmt --check` / `deno lint` / `deno check`（`*.ts`/`*.tsx`、`_fresh/` 除外）
- [x] `deno task test` — 既存の `MicroCmsClient` ネットワークテスト 1 件は live endpoint 非依存環境での既知の失敗（本変更とは無関係。`Dockerfile` はテストから参照されない）。他は green
- [x] ダイジェストが `denoland/deno:2.8.3` の正当な index digest であることをレジストリ照合で確認
- [ ] 実ビルドでの解決確認は CI / Cloud Build に委ねる（ローカルに docker 非稼働のため `docker build` 未実行）

🤖 Generated with [Claude Code](https://claude.com/claude-code)