### PR TITLE
chore(deps): upgrade @octokit/rest 21 -> 22 (major)

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -16,7 +16,7 @@
     "@sitemap/": "./domains/sitemap/",
     "@islands/": "./islands/",
     "@shared/": "./shared/",
-    "octokit": "npm:@octokit/rest@^21.0.0",
+    "octokit": "npm:@octokit/rest@^22.0.0",
     "hljs": "npm:highlight.js@11.11.1",
     "std/path/mod.ts": "jsr:@std/path",
     "std/assert/mod.ts": "jsr:@std/assert",

--- a/deno.lock
+++ b/deno.lock
@@ -29,7 +29,7 @@
     "jsr:@std/semver@^1.0.6": "1.0.8",
     "jsr:@std/testing@*": "1.0.19",
     "jsr:@std/uuid@^1.0.9": "1.1.1",
-    "npm:@octokit/rest@21": "21.1.1",
+    "npm:@octokit/rest@22": "22.0.1",
     "npm:@octokit/rest@22.0.1": "22.0.1",
     "npm:@opentelemetry/api@^1.9.0": "1.9.1",
     "npm:@preact/signals@^2.5.1": "2.9.2_preact@10.29.2",
@@ -344,182 +344,89 @@
         "@jridgewell/sourcemap-codec"
       ]
     },
-    "@octokit/auth-token@5.1.2": {
-      "integrity": "sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw=="
-    },
     "@octokit/auth-token@6.0.0": {
       "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="
-    },
-    "@octokit/core@6.1.6": {
-      "integrity": "sha512-kIU8SLQkYWGp3pVKiYzA5OSaNF5EE03P/R8zEmmrG6XwOg5oBjXyQVVIauQ0dgau4zYhpZEhJrvIYt6oM+zZZA==",
-      "dependencies": [
-        "@octokit/auth-token@5.1.2",
-        "@octokit/graphql@8.2.2",
-        "@octokit/request@9.2.4",
-        "@octokit/request-error@6.1.8",
-        "@octokit/types@14.1.0",
-        "before-after-hook@3.0.2",
-        "universal-user-agent"
-      ]
     },
     "@octokit/core@7.0.6": {
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dependencies": [
-        "@octokit/auth-token@6.0.0",
-        "@octokit/graphql@9.0.3",
-        "@octokit/request@10.0.10",
-        "@octokit/request-error@7.1.0",
-        "@octokit/types@16.0.0",
-        "before-after-hook@4.0.0",
-        "universal-user-agent"
-      ]
-    },
-    "@octokit/endpoint@10.1.4": {
-      "integrity": "sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==",
-      "dependencies": [
-        "@octokit/types@14.1.0",
+        "@octokit/auth-token",
+        "@octokit/graphql",
+        "@octokit/request",
+        "@octokit/request-error",
+        "@octokit/types",
+        "before-after-hook",
         "universal-user-agent"
       ]
     },
     "@octokit/endpoint@11.0.3": {
       "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
       "dependencies": [
-        "@octokit/types@16.0.0",
-        "universal-user-agent"
-      ]
-    },
-    "@octokit/graphql@8.2.2": {
-      "integrity": "sha512-Yi8hcoqsrXGdt0yObxbebHXFOiUA+2v3n53epuOg1QUgOB6c4XzvisBNVXJSl8RYA5KrDuSL2yq9Qmqe5N0ryA==",
-      "dependencies": [
-        "@octokit/request@9.2.4",
-        "@octokit/types@14.1.0",
+        "@octokit/types",
         "universal-user-agent"
       ]
     },
     "@octokit/graphql@9.0.3": {
       "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
       "dependencies": [
-        "@octokit/request@10.0.10",
-        "@octokit/types@16.0.0",
+        "@octokit/request",
+        "@octokit/types",
         "universal-user-agent"
       ]
-    },
-    "@octokit/openapi-types@24.2.0": {
-      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="
-    },
-    "@octokit/openapi-types@25.1.0": {
-      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA=="
     },
     "@octokit/openapi-types@27.0.0": {
       "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="
     },
-    "@octokit/plugin-paginate-rest@11.6.0_@octokit+core@6.1.6": {
-      "integrity": "sha512-n5KPteiF7pWKgBIBJSk8qzoZWcUkza2O6A0za97pMGVrGfPdltxrfmfF5GucHYvHGZD8BdaZmmHGz5cX/3gdpw==",
-      "dependencies": [
-        "@octokit/core@6.1.6",
-        "@octokit/types@13.10.0"
-      ]
-    },
     "@octokit/plugin-paginate-rest@14.0.0_@octokit+core@7.0.6": {
       "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
       "dependencies": [
-        "@octokit/core@7.0.6",
-        "@octokit/types@16.0.0"
-      ]
-    },
-    "@octokit/plugin-request-log@5.3.1_@octokit+core@6.1.6": {
-      "integrity": "sha512-n/lNeCtq+9ofhC15xzmJCNKP2BWTv8Ih2TTy+jatNCCq/gQP/V7rK3fjIfuz0pDWDALO/o/4QY4hyOF6TQQFUw==",
-      "dependencies": [
-        "@octokit/core@6.1.6"
+        "@octokit/core",
+        "@octokit/types"
       ]
     },
     "@octokit/plugin-request-log@6.0.0_@octokit+core@7.0.6": {
       "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
       "dependencies": [
-        "@octokit/core@7.0.6"
-      ]
-    },
-    "@octokit/plugin-rest-endpoint-methods@13.5.0_@octokit+core@6.1.6": {
-      "integrity": "sha512-9Pas60Iv9ejO3WlAX3maE1+38c5nqbJXV5GrncEfkndIpZrJ/WPMRd2xYDcPPEt5yzpxcjw9fWNoPhsSGzqKqw==",
-      "dependencies": [
-        "@octokit/core@6.1.6",
-        "@octokit/types@13.10.0"
+        "@octokit/core"
       ]
     },
     "@octokit/plugin-rest-endpoint-methods@17.0.0_@octokit+core@7.0.6": {
       "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
       "dependencies": [
-        "@octokit/core@7.0.6",
-        "@octokit/types@16.0.0"
-      ]
-    },
-    "@octokit/request-error@6.1.8": {
-      "integrity": "sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==",
-      "dependencies": [
-        "@octokit/types@14.1.0"
+        "@octokit/core",
+        "@octokit/types"
       ]
     },
     "@octokit/request-error@7.1.0": {
       "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
       "dependencies": [
-        "@octokit/types@16.0.0"
+        "@octokit/types"
       ]
     },
     "@octokit/request@10.0.10": {
       "integrity": "sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==",
       "dependencies": [
-        "@octokit/endpoint@11.0.3",
-        "@octokit/request-error@7.1.0",
-        "@octokit/types@16.0.0",
+        "@octokit/endpoint",
+        "@octokit/request-error",
+        "@octokit/types",
         "content-type",
         "json-with-bigint",
         "universal-user-agent"
       ]
     },
-    "@octokit/request@9.2.4": {
-      "integrity": "sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA==",
-      "dependencies": [
-        "@octokit/endpoint@10.1.4",
-        "@octokit/request-error@6.1.8",
-        "@octokit/types@14.1.0",
-        "fast-content-type-parse",
-        "universal-user-agent"
-      ]
-    },
-    "@octokit/rest@21.1.1": {
-      "integrity": "sha512-sTQV7va0IUVZcntzy1q3QqPm/r8rWtDCqpRAmb8eXXnKkjoQEtFe3Nt5GTVsHft+R6jJoHeSiVLcgcvhtue/rg==",
-      "dependencies": [
-        "@octokit/core@6.1.6",
-        "@octokit/plugin-paginate-rest@11.6.0_@octokit+core@6.1.6",
-        "@octokit/plugin-request-log@5.3.1_@octokit+core@6.1.6",
-        "@octokit/plugin-rest-endpoint-methods@13.5.0_@octokit+core@6.1.6"
-      ]
-    },
     "@octokit/rest@22.0.1": {
       "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
       "dependencies": [
-        "@octokit/core@7.0.6",
-        "@octokit/plugin-paginate-rest@14.0.0_@octokit+core@7.0.6",
-        "@octokit/plugin-request-log@6.0.0_@octokit+core@7.0.6",
-        "@octokit/plugin-rest-endpoint-methods@17.0.0_@octokit+core@7.0.6"
-      ]
-    },
-    "@octokit/types@13.10.0": {
-      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
-      "dependencies": [
-        "@octokit/openapi-types@24.2.0"
-      ]
-    },
-    "@octokit/types@14.1.0": {
-      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
-      "dependencies": [
-        "@octokit/openapi-types@25.1.0"
+        "@octokit/core",
+        "@octokit/plugin-paginate-rest",
+        "@octokit/plugin-request-log",
+        "@octokit/plugin-rest-endpoint-methods"
       ]
     },
     "@octokit/types@16.0.0": {
       "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
       "dependencies": [
-        "@octokit/openapi-types@27.0.0"
+        "@octokit/openapi-types"
       ]
     },
     "@opentelemetry/api@1.9.1": {
@@ -647,9 +554,6 @@
     "base64-js@0.0.8": {
       "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw=="
     },
-    "before-after-hook@3.0.2": {
-      "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A=="
-    },
     "before-after-hook@4.0.0": {
       "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="
     },
@@ -743,9 +647,6 @@
     },
     "escape-html@1.0.3": {
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
-    },
-    "fast-content-type-parse@2.0.1": {
-      "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q=="
     },
     "fflate@0.7.4": {
       "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw=="
@@ -1352,7 +1253,7 @@
       "jsr:@std/assert@*",
       "jsr:@std/path@*",
       "jsr:@std/testing@*",
-      "npm:@octokit/rest@21",
+      "npm:@octokit/rest@22",
       "npm:@preact/signals@^2.9.2",
       "npm:@resvg/resvg-wasm@^2.6.2",
       "npm:clsx@^2.1.1",


### PR DESCRIPTION
## Summary

- GitHub API クライアント `@octokit/rest` を major v21 → v22 へ更新する。アプリコードの変更は不要

## 変更

- **`deno.jsonc` / `deno.lock`**: `@octokit/rest` `^21.0.0` → `^22.0.0`（lock は 22.0.1 に解決）
  - v22 の破壊的変更は「Node 18 サポート終了」「deprecated Projects エンドポイント削除」「deprecated Copilot usage metrics エンドポイント削除」の3点。本コードの GitHub 呼び出しは `octokit.request("GET /users/{username}/repos", ...)` のみで、いずれにも該当しない（Deno 実行なので Node 18 も無関係）
  - `shared/github/` のコード（`core.ts` / `repositories.ts`）は無変更
  - `deno.lock` が大きく縮小しているのは、v22 で octokit の依存ツリーが整理され transitive 依存が減ったため（変更は `@octokit/*` のサブツリーに限定。他の top-level 依存は不変）

## Test plan

- [x] `deno check`（`*.ts`/`*.tsx`、`_fresh/` 除外）— v22 型に対し型検査通過
- [x] `deno test shared/github/` — 2 件 green（`getMyRepositories`）
- [x] `deno task test` 全体 — 既存の `MicroCmsClient` ネットワークテスト 1 件のみ既知の失敗（live endpoint 非依存環境）で、他は green
- [x] `deno task build`（本番ビルド）

🤖 Generated with [Claude Code](https://claude.com/claude-code)