### PR TITLE
chore(deps): upgrade satori 0.18 -> 0.26

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -37,7 +37,7 @@
     "preact": "npm:preact@^10.27.2",
     "preact/hooks": "npm:preact@^10.27.2/hooks",
     "preact/jsx-runtime": "npm:preact@^10.27.2/jsx-runtime",
-    "satori": "npm:satori@^0.18.3",
+    "satori": "npm:satori@^0.26.0",
     "fresh": "jsr:@fresh/core@^2.3.3",
     "fresh/dev": "jsr:@fresh/core@^2.3.3/dev",
     "fresh/runtime": "jsr:@fresh/core@^2.3.3/runtime",

--- a/deno.lock
+++ b/deno.lock
@@ -51,8 +51,8 @@
     "npm:preact@^10.27.2": "10.29.2",
     "npm:preact@^10.28.2": "10.29.2",
     "npm:preact@^10.29.1": "10.29.2",
+    "npm:satori@0.26": "0.26.0",
     "npm:satori@0.26.0": "0.26.0",
-    "npm:satori@~0.18.3": "0.18.4",
     "npm:tailwindcss@^4.3.1": "4.3.1",
     "npm:zod@^4.4.3": "4.4.3"
   },
@@ -814,22 +814,6 @@
     "preact@10.29.2": {
       "integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ=="
     },
-    "satori@0.18.4": {
-      "integrity": "sha512-HanEzgXHlX3fzpGgxPoR3qI7FDpc/B+uE/KplzA6BkZGlWMaH98B/1Amq+OBF1pYPlGNzAXPYNHlrEVBvRBnHQ==",
-      "dependencies": [
-        "@shuding/opentype.js",
-        "css-background-parser",
-        "css-box-shadow",
-        "css-gradient-parser",
-        "css-to-react-native",
-        "emoji-regex-xs",
-        "escape-html",
-        "linebreak",
-        "parse-css-color",
-        "postcss-value-parser",
-        "yoga-layout"
-      ]
-    },
     "satori@0.26.0": {
       "integrity": "sha512-tkMFrfIs3l2mQ2JEcyW0ADTy3zGggFRFzi6Ef8YozQSFsFKEqaSO1Y8F9wJg4//PJGQauMalHGTUEkPrFwhVPA==",
       "dependencies": [
@@ -1263,7 +1247,7 @@
       "npm:i18next@^24.2.1",
       "npm:parse5@^8.0.1",
       "npm:preact@^10.27.2",
-      "npm:satori@~0.18.3",
+      "npm:satori@0.26",
       "npm:tailwindcss@^4.3.1",
       "npm:zod@^4.4.3"
     ]


### PR DESCRIPTION
## Summary

- OG 画像生成に使う `satori` を 0.18.4 → 0.26.0 へ更新する。アプリコードの変更は不要

## 変更

- **`deno.jsonc` / `deno.lock`**: `satori` `^0.18.3` → `^0.26.0`（lock は 0.26.0 に解決）
  - 0.19〜0.26 のリリースはいずれも additive な機能追加（CSS variables、object-fit、text-indent、background-size、builtin JSX runtime 等）とバグ修正で、本コードが使う API には破壊的変更なし
  - `domains/og/generator/` の satori 使用は `satori(element, options)`（flexbox レイアウト + 絶対配置 + テキスト）と `SatoriOptions["fonts"]` 型のみで、いずれも 0.26 で不変
  - satori の transitive 依存は 0.18.4 と同一（追加・削除なし）。他の top-level 依存も不変

## Test plan

- [x] `deno check`（`*.ts`/`*.tsx`、`_fresh/` 除外）— satori 0.26 型に対し OG generator が型検査通過
- [x] `deno test domains/og/` — 4 件 green（generator が satori 0.26 をランタイム実行し SVG 文字列を返すことを確認）
- [x] `deno task test` 全体 — 既存の `MicroCmsClient` ネットワークテスト 1 件のみ既知の失敗（live endpoint 非依存環境）で、他は green
- [x] `deno task build`（本番ビルド）
- [ ] OG 画像（square / text / icon）の目視確認 — generator テストは文字列存在のみの検証でレイアウト変化を捕捉しないため、デプロイ後または `deno task preview` で表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)