### PR TITLE
chore(deps): upgrade i18next 24 -> 26 + add i18n unit tests

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -23,7 +23,7 @@
     "std/testing/bdd.ts": "jsr:@std/testing/bdd",
     "std/testing/snapshot.ts": "jsr:@std/testing/snapshot",
     "std/testing/mock.ts": "jsr:@std/testing/mock",
-    "i18next": "npm:i18next@^24.2.1",
+    "i18next": "npm:i18next@^26.0.0",
     "resvg/": "./shared/resvg/",
     "@resvg/resvg-wasm": "npm:@resvg/resvg-wasm@^2.6.2",
     "zod": "npm:zod@^4.4.3",

--- a/deno.lock
+++ b/deno.lock
@@ -43,8 +43,8 @@
     "npm:esbuild@0.25.7": "0.25.7",
     "npm:esbuild@~0.25.5": "0.25.7",
     "npm:highlight.js@11.11.1": "11.11.1",
+    "npm:i18next@26": "26.3.1",
     "npm:i18next@26.3.1": "26.3.1",
-    "npm:i18next@^24.2.1": "24.2.3",
     "npm:parse5@^8.0.1": "8.0.1",
     "npm:postcss@8.5.6": "8.5.6",
     "npm:preact-render-to-string@^6.6.3": "6.7.0_preact@10.29.2",
@@ -183,9 +183,6 @@
   "npm": {
     "@alloc/quick-lru@5.2.0": {
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="
-    },
-    "@babel/runtime@7.28.6": {
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="
     },
     "@esbuild/aix-ppc64@0.25.7": {
       "integrity": "sha512-uD0kKFHh6ETr8TqEtaAcV+dn/2qnYbH/+8wGEdY70Qf7l1l/jmBUbrmQqwiPKAQE6cOQ7dTj6Xr0HzQDGHyceQ==",
@@ -659,12 +656,6 @@
     },
     "highlight.js@11.11.1": {
       "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="
-    },
-    "i18next@24.2.3": {
-      "integrity": "sha512-lfbf80OzkocvX7nmZtu7nSTNbrTYR52sLWxPtlXX1zAhVw8WEnFk4puUkCR4B1dNQwbSpEHHHemcZu//7EcB7A==",
-      "dependencies": [
-        "@babel/runtime"
-      ]
     },
     "i18next@26.3.1": {
       "integrity": "sha512-txQqd5EULsqEh9OJqRH15aCaOuy/nLJyhw5EHCSKLKJE1aBbb3Zve2+uQIxgWhPm1QqUQoWyQBm2kfmmIrzkcQ=="
@@ -1244,7 +1235,7 @@
       "npm:dayjs@1.11.21",
       "npm:dayjs@^1.11.21",
       "npm:highlight.js@11.11.1",
-      "npm:i18next@^24.2.1",
+      "npm:i18next@26",
       "npm:parse5@^8.0.1",
       "npm:preact@^10.27.2",
       "npm:satori@0.26",

--- a/shared/i18n/core_test.ts
+++ b/shared/i18n/core_test.ts
@@ -1,0 +1,54 @@
+import { describe, it } from "std/testing/bdd.ts";
+import { assertEquals } from "std/assert/mod.ts";
+import i18n from "i18next";
+import { init } from "./core.ts";
+import { translate } from "./translate.ts";
+import { ja } from "./locales/mod.ts";
+
+// `i18next` is a global singleton shared by core.ts, translate.ts and this test.
+// `init` guards on `i18n.isInitialized`, so once any test (here or elsewhere in
+// the same `deno test` run) initializes it, the instance stays initialized.
+// These tests therefore ensure initialization themselves and assert behavior
+// that holds regardless of which test ran first.
+describe("i18n init behavior", () => {
+  it("marks i18next as initialized after init", async () => {
+    await init({ lang: "ja" });
+
+    assertEquals(i18n.isInitialized, true);
+  });
+
+  it("sets the language to the passed lang", async () => {
+    await init({ lang: "ja" });
+
+    assertEquals(i18n.language, "ja");
+  });
+
+  it("configures 'ja' as the fallback language", async () => {
+    await init({ lang: "ja" });
+
+    // i18next normalizes `fallbackLng` to an array internally.
+    assertEquals(i18n.options.fallbackLng, ["ja"]);
+  });
+
+  it("loads the ja resources so real keys resolve to their ja values", async () => {
+    // Indirect verification that `resources: { ja }` was registered: a real key
+    // from ja.ts must resolve to its ja value after init.
+    await init({ lang: "ja" });
+
+    assertEquals(translate("profile:heading"), ja.profile.heading);
+  });
+
+  it("is a no-op when called again while already initialized", async () => {
+    // Reach a known-initialized state first (idempotent thanks to the guard).
+    await init({ lang: "ja" });
+    assertEquals(i18n.isInitialized, true);
+
+    // A second call with a different lang must hit the `isInitialized` guard and
+    // return early: it must not throw, must not re-initialize, and must not
+    // change the already-resolved language.
+    await init({ lang: "en" });
+
+    assertEquals(i18n.isInitialized, true);
+    assertEquals(i18n.language, "ja");
+  });
+});

--- a/shared/i18n/translate_test.ts
+++ b/shared/i18n/translate_test.ts
@@ -1,0 +1,85 @@
+import { describe, it } from "std/testing/bdd.ts";
+import { assertEquals } from "std/assert/mod.ts";
+import { init } from "./core.ts";
+import { translate } from "./translate.ts";
+import { ja } from "./locales/mod.ts";
+
+// `translate` delegates to the global i18next singleton, which `init` configures.
+// `init` is idempotent (guards on `isInitialized`), so each test ensures the
+// singleton is initialized before exercising `translate` — this keeps the file
+// order-independent even though the singleton state is shared process-wide.
+
+// The key type is intentionally exhaustive in production (`TranslateKey`), so it
+// is not exported. Derive it from `translate`'s own signature to reference it
+// here without changing production code.
+type TranslateArg = Parameters<typeof translate>[0];
+
+describe("translate behavior", () => {
+  it("resolves a 'namespace:key' string to its ja value", async () => {
+    await init({ lang: "ja" });
+
+    assertEquals(translate("profile:heading"), ja.profile.heading);
+  });
+
+  it("resolves keys across multiple namespaces using the ':' separator", async () => {
+    await init({ lang: "ja" });
+
+    assertEquals(translate("home:heading"), ja.home.heading);
+    assertEquals(translate("social:github"), ja.social.github);
+    assertEquals(translate("immutable:updatedDate"), ja.immutable.updatedDate);
+  });
+
+  it("resolves an array of keys to the first matching translation", async () => {
+    await init({ lang: "ja" });
+
+    assertEquals(
+      translate(["profile:heading", "home:heading"]),
+      ja.profile.heading,
+    );
+  });
+
+  it("interpolates {{var}} placeholders from option values", async () => {
+    await init({ lang: "ja" });
+
+    // Mirrors the two real interpolation call sites:
+    // - Posts.tsx     -> translate("posts:total", { total: String(...) })
+    // - Copyright.tsx -> translate("footer:copyright", { year: currentYear })
+    // Values are passed as strings to match TranslateOption's `& Record<string,
+    // string>` typing (the call sites stringify their inputs, so no new `as` is
+    // needed). Expected values are derived from the real ja.* strings via
+    // `.replace`, keeping the no-duplicate-literals discipline of this file.
+    assertEquals(
+      translate("posts:total", { total: "12" }),
+      ja.posts.total.replace("{{total}}", "12"),
+    );
+    assertEquals(
+      translate("footer:copyright", { year: "2026" }),
+      ja.footer.copyright.replace("{{year}}", "2026"),
+    );
+  });
+
+  it("returns option.defaultValue for an undefined key", async () => {
+    await init({ lang: "ja" });
+
+    // `TranslateKey` is exhaustive over the keys defined in ja.ts, so no valid
+    // key resolves to "missing" — there is genuinely no type-safe way to feed
+    // `translate` an undefined key. A single, isolated assertion is the lowest
+    // cost way to exercise the i18next `defaultValue` fallback path.
+    const undefinedKey = "profile:does-not-exist" as TranslateArg;
+
+    assertEquals(
+      translate(undefinedKey, { defaultValue: "FALLBACK" }),
+      "FALLBACK",
+    );
+  });
+
+  it("returns a value assignable to string (i18next v26 t() return type guard)", async () => {
+    await init({ lang: "ja" });
+
+    // Type-level regression guard: if i18next's `t()` return type stops being
+    // assignable to `string`, this assignment fails `deno check`.
+    const result: string = translate("profile:heading");
+
+    assertEquals(result, ja.profile.heading);
+  });
+});


### PR DESCRIPTION
## Summary

- i18n ライブラリ `i18next` を 2 メジャー（v24 → v26）更新する
- あわせて、これまでテストの無かった i18n の `init` / `translate` ランタイム経路に直接のユニットテストを追加する（バージョン更新時の回帰を検知できるようにする）

## 変更

- **`deno.jsonc` / `deno.lock`**: `i18next` `^24.2.1` → `^26.0.0`（lock は 26.3.1 に解決）
  - v25（`changeLanguage` のマッチ順/フォールバック調整）と v26（非推奨オプション `initImmediate` / `interpolation.format` / `simplifyPluralSuffix` / `showSupportNotice` の削除）の破壊的変更は本コードに非該当。使用は `i18n.init({ lng, fallbackLng, resources: { ja } })` と `i18n.t(key, option)` のみで `changeLanguage` 未使用
  - production コード（`shared/i18n/core.ts` / `translate.ts`）は無変更
- **`shared/i18n/core_test.ts`（新規）**: `init` のテスト — `isInitialized` 化、`lng` 反映、`fallbackLng`（i18next が `["ja"]` に正規化）、`ja` リソース読込（実翻訳の解決で間接確認）、`isInitialized` ガードによる再 init の no-op
- **`shared/i18n/translate_test.ts`（新規）**: `translate` のテスト — `ns:key` の `:` 解決、複数 namespace、配列キー、`{{var}}` インターポレーション（実呼び出し元 `posts:total` の `{{total}}`・`footer:copyright` の `{{year}}` に対応）、`defaultValue` フォールバック、`t()` 戻り値の `string` 代入性（バージョン回帰ガード）
  - アサーションは `import { ja }` で実リソース値から導出（リテラル重複なし）

## Test plan

- [x] `deno test shared/i18n/` — init/translate の新規テストを含めて green
- [x] `deno fmt --check` / `deno lint` / `deno check`（`*.ts`/`*.tsx`、`_fresh/` 除外）
- [x] `deno task test` 全体 — 既存の `MicroCmsClient` ネットワークテスト 1 件のみ既知の失敗（live endpoint 非依存環境）で、他は green
- [x] `deno task build`（本番ビルド・SSR が `translate()` を実行）

🤖 Generated with [Claude Code](https://claude.com/claude-code)