### PR TITLE
fix(github): restore effective request timeout via AbortSignal

### DIFF
--- a/shared/github/_mock.ts
+++ b/shared/github/_mock.ts
@@ -1,7 +1,10 @@
 import type { OctokitInstance } from "./core.ts";
 
 export type MockOption = {
-  request?: () => Promise<unknown>;
+  request?: (
+    resource: string,
+    input?: Record<string, unknown>,
+  ) => Promise<unknown>;
 };
 
 export function createOctokitMock(option: MockOption): OctokitInstance {

--- a/shared/github/core.ts
+++ b/shared/github/core.ts
@@ -15,11 +15,7 @@ export type OctokitInstance = {
 let octokit: Octokit;
 export function getOctokit(): OctokitInstance {
   if (!octokit) {
-    octokit = new Octokit({
-      request: {
-        timeout: 5000,
-      },
-    });
+    octokit = new Octokit();
   }
   return octokit;
 }

--- a/shared/github/repositories.ts
+++ b/shared/github/repositories.ts
@@ -12,21 +12,21 @@ type GetMyRepositoriesInput = {
   perPage?: number;
 };
 
-export function getMyRepositories(
+const requestTimeoutMs = 5000;
+
+export async function getMyRepositories(
   octokit: OctokitInstance,
   option?: GetMyRepositoriesInput,
 ): Promise<Repository[]> {
   const { perPage = 3 } = option ?? {};
-  return Promise.race([
-    octokit.request<Repository[]>(
-      "GET /users/{username}/repos",
-      {
-        username: "mya-ake",
-        sort: "pushed",
-        per_page: perPage,
-      },
-    ).then((res) => res.data),
-  ]).catch((err: unknown) => {
-    return Promise.reject(err);
-  });
+  const res = await octokit.request<Repository[]>(
+    "GET /users/{username}/repos",
+    {
+      username: "mya-ake",
+      sort: "pushed",
+      per_page: perPage,
+      request: { signal: AbortSignal.timeout(requestTimeoutMs) },
+    },
+  );
+  return res.data;
 }

--- a/shared/github/repositories_test.ts
+++ b/shared/github/repositories_test.ts
@@ -1,7 +1,23 @@
 import { describe, it } from "std/testing/bdd.ts";
-import { assertEquals, assertRejects } from "std/assert/mod.ts";
+import { assert, assertEquals, assertRejects } from "std/assert/mod.ts";
 import { getMyRepositories, Repository } from "./repositories.ts";
 import { createOctokitMock } from "./_mock.ts";
+
+// Narrow the request signal out of the captured input without `as`.
+// `input.request` is `unknown`; guard it down to an AbortSignal.
+function extractSignal(
+  input: Record<string, unknown> | undefined,
+): AbortSignal | undefined {
+  const request = input?.request;
+  if (typeof request !== "object" || request === null) {
+    return undefined;
+  }
+  if (!("signal" in request)) {
+    return undefined;
+  }
+  const { signal } = request;
+  return signal instanceof AbortSignal ? signal : undefined;
+}
 
 describe("getMyRepositories", () => {
   it("response from octokit", async () => {
@@ -28,5 +44,44 @@ describe("getMyRepositories", () => {
       () => getMyRepositories(octokitMock, { perPage: 3 }),
       "test_error",
     );
+  });
+
+  it("attaches a timeout AbortSignal to the octokit request", async () => {
+    let captured: Record<string, unknown> | undefined;
+    const octokitMock = createOctokitMock({
+      request: (_resource, input) => {
+        captured = input;
+        return Promise.resolve({ data: [] });
+      },
+    });
+    await getMyRepositories(octokitMock, { perPage: 3 });
+
+    const signal = extractSignal(captured);
+    assert(signal instanceof AbortSignal);
+    // The signal is fresh per-call: not yet aborted right after the request.
+    assertEquals(signal.aborted, false);
+  });
+
+  it("defaults perPage to 3 when no option is given", async () => {
+    let captured: Record<string, unknown> | undefined;
+    const octokitMock = createOctokitMock({
+      request: (_resource, input) => {
+        captured = input;
+        return Promise.resolve({ data: [] });
+      },
+    });
+    await getMyRepositories(octokitMock);
+
+    assertEquals(captured?.per_page, 3);
+  });
+
+  it("AbortSignal.timeout aborts with a TimeoutError", async () => {
+    const signal = AbortSignal.timeout(0);
+    // Let the microtask/timer queue flush so the 0ms timeout fires.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    assertEquals(signal.aborted, true);
+    assert(signal.reason instanceof DOMException);
+    assertEquals(signal.reason.name, "TimeoutError");
   });
 });


### PR DESCRIPTION
## Summary

- Home ページで GitHub リポジトリ一覧を取得する API リクエストに、実効的なタイムアウトが効いていなかった問題を修正する
  - `shared/github/core.ts` が Octokit のコンストラクタに渡していた `request: { timeout: 5000 }` は、現行 Octokit（native fetch ベース）では読まれず**ランタイムで無視される**（`@octokit/request` v10 のリクエスト経路に `timeout` の参照は無い）
  - `shared/github/repositories.ts` の `Promise.race([<単一要素>])` も 1 要素のレースで実質 no-op だった
  - 結果として、GitHub のレスポンスがハングすると Home の SSR レンダリングが無限に待たされうる状態だった

## 変更

- **`shared/github/repositories.ts`**: `getMyRepositories` で `octokit.request(..., { request: { signal: AbortSignal.timeout(requestTimeoutMs) } })` を渡し、リクエストごとに実効 ~5s タイムアウトを付与（`AbortSignal.timeout` は octokit 経由で native fetch の `signal` に転送される）。タイムアウト値は named 定数 `requestTimeoutMs = 5000`。no-op だった `Promise.race` と pass-through な `.catch` を除去（rejection は従来どおり伝播）
- **`shared/github/core.ts`**: 無視されていた `request: { timeout: 5000 }` を削除し `new Octokit()` に。`getOctokit()` のシングルトンと `OctokitInstance` 型契約は不変
- **`shared/github/_mock.ts`**: テストが渡された入力を型安全に検査できるよう、モックの `request` パラメータ型を実 request の形に拡張
- **`shared/github/repositories_test.ts`**: 既存2ケースを維持しつつ、タイムアウト `AbortSignal` がリクエストに付与されること・`perPage` 既定値・`AbortSignal.timeout` の `TimeoutError` セマンティクスを検証するケースを追加

呼び出し元 `domains/home/pages/resource/github.ts` は従来どおり `.catch(() => [])` で失敗時に空リストへ degrade するため、タイムアウト時は空のリポジトリ一覧で SSR が継続する（挙動不変・無変更）。

## Test plan

- [x] `deno test shared/github/` — 既存2ケース＋追加ケースすべて green
- [x] `deno fmt --check` / `deno lint` / `deno check`（`*.ts`/`*.tsx`、`_fresh/` 除外）
- [x] `deno task test` 全体 — 既存の `MicroCmsClient` ネットワークテスト 1 件のみ既知の失敗（live endpoint 非依存環境）で、他は green
- [x] `deno task build`（本番ビルド）

🤖 Generated with [Claude Code](https://claude.com/claude-code)